### PR TITLE
Add caching faraday middleware [WIP]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ gem 'webmock',      require: false
 gem 'pry-nav',      require: false
 gem 'rack-test',    require: false
 gem 'dotenv',       require: false
-gem 'faraday',      require: false
 gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ gem 'webmock',      require: false
 gem 'pry-nav',      require: false
 gem 'rack-test',    require: false
 gem 'dotenv',       require: false
+gem 'faraday',      require: false
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   dotenv
+  faraday
   guard-rspec
   pry-nav
   psych
@@ -128,4 +129,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ PLATFORMS
 DEPENDENCIES
   bundler
   dotenv
-  faraday
   guard-rspec
   pry-nav
   psych
@@ -129,4 +128,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ whenever the drain gets notified about a change on that widget.
 Note that `Cache#fget` is a future, so you can efficiently query many resources
 and have any `HTTP GET` requests (and cache queries) happen in parallel.
 
+Using `#get` and `#fget` will use the internal fetcher of `Cache`, which is based
+on Faraday. If you want to be able to use your own client for fetching the requests
+themselves, you can use `Cache#fetch` which accepts a block, following on from the
+above example, you can use it like so:
+
+```ruby
+require 'net/http'
+
+@cache.fetch('https://example.com/widgets/123') do |url|
+  Net::HTTP.get(URI.parse(url)) #=> String
+end
+ ```
+
 See
 [rubydoc](http://rubydoc.info/github/mezis/routemaster-drain/Routemaster/Cache)
 for more details on `Cache`.

--- a/README.md
+++ b/README.md
@@ -212,14 +212,19 @@ and have any `HTTP GET` requests (and cache queries) happen in parallel.
 
 Using `#get` and `#fget` will use the internal fetcher of `Cache`, which is based
 on Faraday. If you want to be able to use your own client for fetching the requests
-themselves, you can use `Cache#fetch` which accepts a block, following on from the
+themselves, you can use `Cache#fetch` which accepts a block which must return an object that responds to #to_json, with status, code and body fields. Following on from the
 above example, you can use it like so:
 
 ```ruby
-require 'net/http'
+require 'httparty'
 
 @cache.fetch('https://example.com/widgets/123') do |url|
-  Net::HTTP.get(URI.parse(url)) #=> String
+  {}.tap do |r|
+  	response = HTTParty.get(url)
+  	r.status = response.status
+  	r.code = response.code
+  	r.body = response.body
+  end #=> Hash {body:, status:, headers:}
 end
  ```
 

--- a/lib/routemaster/cache.rb
+++ b/lib/routemaster/cache.rb
@@ -38,7 +38,7 @@ module Routemaster
     # Wraps a future response, so it quacks exactly like an ordinary response.
     class FutureResponse
       extend Forwardable
-     
+
       # The `block` is expected to return a {Response}
       def initialize(&block)
         @future = Pool.instance.future(&block)
@@ -47,15 +47,15 @@ module Routemaster
       # @!attribute status
       # @return [Integer]
       # Delegated to the `block`'s return value.
-      
+
       # @!attribute headers
       # @return [Hash]
       # Delegated to the `block`'s return value.
-      
+
       # @!attribute body
       # @return pHashie::Mash]
       # Delegated to the `block`'s return value.
-      
+
       delegate :value => :@future
       delegate %i(status headers body) => :value
     end
@@ -63,10 +63,10 @@ module Routemaster
     class Response < Hashie::Mash
       # @!attribute status
       # Integer
-      
+
       # @!attribute headers
       # Hash
-      
+
       # @!attribute body
       # Hashie::Mash
     end
@@ -95,29 +95,16 @@ module Routemaster
     #
     # @return [Response], which responds to `status`, `headers`, and `body`.
     def get(url, version:nil, locale:nil)
-      key   = "cache:#{url}"
-      field = "v:#{version},l:#{locale}"
-
-      # check cache
-      if payload = @redis.hget(key, field)
-        publish(:cache_hit, url)
-        return Response.new(JSON.parse(payload))
-      end
-
-      # fetch data
-      headers = {
-        'Accept' => version ?
+      response = with_caching(url, version: version, locale: locale) do
+        # fetch data
+        headers = {
+          'Accept' => version ?
           "application/json;v=#{version}" :
           "application/json"
-      }
-      headers['Accept-Language'] = locale if locale
-      response = @fetcher.get(url, headers: headers)
-
-      # store in redis
-      @redis.hset(key, field, response.to_json)
-      @redis.expire(key, @expiry)
-
-      publish(:cache_miss, url)
+        }
+        headers['Accept-Language'] = locale if locale
+        @fetcher.get(url, headers: headers)
+      end
       Response.new(response)
     end
 
@@ -128,6 +115,26 @@ module Routemaster
     # like [Response].
     def fget(*args)
       FutureResponse.new { get(*args) }
+    end
+
+    def with_caching(url, version: nil, locale: nil)
+      key   = "cache:#{url}"
+      field = "v:#{version},l:#{locale}"
+
+      # check cache
+      if payload = @redis.hget(key, field)
+        publish(:cache_hit, url)
+        return Response.new(JSON.parse(payload))
+      end
+
+      response = yield
+
+      # store in redis
+      @redis.hset(key, field, response.to_json)
+      @redis.expire(key, @expiry)
+
+      publish(:cache_miss, url)
+      response
     end
   end
 end

--- a/lib/routemaster/faraday_middleware/caching.rb
+++ b/lib/routemaster/faraday_middleware/caching.rb
@@ -21,7 +21,7 @@ module Routemaster::FaradayMiddleware
       end
 
       args = options.empty? ? [url] : [url, options]
-      cache.with_caching(*args) do
+      cache.fetch(*args) do
         app.call(env)
       end
     end

--- a/lib/routemaster/faraday_middleware/caching.rb
+++ b/lib/routemaster/faraday_middleware/caching.rb
@@ -1,0 +1,46 @@
+require 'routemaster/cache'
+
+module Routemaster::FaradayMiddleware
+  class Caching
+
+    def initialize(app, cache = Routemaster::Cache.new)
+      @app = app
+      @cache = cache
+    end
+
+    def call(env)
+      return app.call(env) unless env.method == :get
+
+      url, version, locale = url(env), version(env), locale(env)
+
+      options = {}.tap do |o|
+        o[:locale]  = locale if locale
+        o[:version] = version if version
+      end
+
+      args = options.empty? ? [url] : [url, options]
+      cache.with_caching(*args) do
+        app.call(env)
+      end
+    end
+
+    private
+
+    attr_reader :cache, :app
+
+    def url(request_env)
+      request_env.url.to_s
+    end
+
+    VERSION_REGEX = /application\/json;v=(?<version>\S*)/.freeze
+
+    def version(request_env)
+      accept = request_env.request_headers['Accept']
+      VERSION_REGEX.match(accept) { |match| match[:version] }
+    end
+
+    def locale(request_env)
+      request_env.request_headers['Accept-Language']
+    end
+  end
+end

--- a/lib/routemaster/faraday_middleware/caching.rb
+++ b/lib/routemaster/faraday_middleware/caching.rb
@@ -11,7 +11,9 @@ module Routemaster::FaradayMiddleware
     def call(env)
       return app.call(env) unless env.method == :get
 
-      url, version, locale = url(env), version(env), locale(env)
+      url = url(env)
+      version = version(env)
+      locale = locale(env)
 
       options = {}.tap do |o|
         o[:locale]  = locale if locale

--- a/spec/routemaster/cache_spec.rb
+++ b/spec/routemaster/cache_spec.rb
@@ -114,7 +114,12 @@ describe Routemaster::Cache do
         i = 0
         Proc.new {
           i += 1
-          "I am a response #{i}"
+
+          Hashie::Mash.new ({
+            status: 200,
+            body: "I am a response #{i}",
+            headers: nil
+          })
         }
     }
 
@@ -125,7 +130,7 @@ describe Routemaster::Cache do
 
       3.times { performer.call(url) }
 
-      expect(performer.call(url)).to eq("I am a response 1")
+      expect(performer.call(url).body).to eq("I am a response 1")
     end
 
     context 'with a listener' do
@@ -143,8 +148,8 @@ describe Routemaster::Cache do
         expect(custom_fetcher).to receive(:get).with(url, anything, anything, &incrementing_endpoint).twice
 
         expect(listener).to receive(:cache_miss).twice
-        expect(performer.call(url, locale: 'en')).to eq "I am a response 1"
-        expect(performer.call(url, locale: 'fr')).to eq "I am a response 2"
+        expect(performer.call(url, locale: 'en').body).to eq "I am a response 1"
+        expect(performer.call(url, locale: 'fr').body).to eq "I am a response 2"
       end
 
       it 'emits :cache_miss' do

--- a/spec/routemaster/faraday_middleware/caching_spec.rb
+++ b/spec/routemaster/faraday_middleware/caching_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'faraday'
+require 'routemaster/faraday_middleware/caching'
+
+describe Routemaster::FaradayMiddleware::Caching do
+
+  let(:cache) { double.as_null_object }
+  let(:app) { double.as_null_object }
+
+  let(:faraday_client) {
+    Faraday.new 'http://www.example.com' do |conn|
+      conn.use Routemaster::FaradayMiddleware::Caching, cache
+    end
+  }
+
+  context 'With supplied Accept and Accept-Language headers' do
+    it 'parses url, version and locale from the request headers and passes \
+    them to the cache#with_caching' do
+      expect(cache).to receive(:with_caching).with('http://www.example.com/anything', version: '1', locale: 'en').and_yield
+      expect_any_instance_of(described_class).to receive(:app) { app }
+      expect(app).to receive(:call)
+
+      faraday_client.get('/anything') do |req|
+        req.headers['Accept'] = "application/json;v=1"
+        req.headers['Accept-Language'] = "en"
+      end
+    end
+  end
+
+  context 'Without Accept and Accept-Language headers' do
+    it 'only calles cache#with_caching with the url' do
+      expect(cache).to receive(:with_caching).with('http://www.example.com/anything').and_yield
+      expect_any_instance_of(described_class).to receive(:app) { app }
+      expect(app).to receive(:call)
+
+      faraday_client.get('/anything')
+    end
+  end
+end

--- a/spec/routemaster/faraday_middleware/caching_spec.rb
+++ b/spec/routemaster/faraday_middleware/caching_spec.rb
@@ -15,8 +15,8 @@ describe Routemaster::FaradayMiddleware::Caching do
 
   context 'With supplied Accept and Accept-Language headers' do
     it 'parses url, version and locale from the request headers and passes \
-    them to the cache#with_caching' do
-      expect(cache).to receive(:with_caching).with('http://www.example.com/anything', version: '1', locale: 'en').and_yield
+    them to cache#fetch' do
+      expect(cache).to receive(:fetch).with('http://www.example.com/anything', version: '1', locale: 'en').and_yield
       expect_any_instance_of(described_class).to receive(:app) { app }
       expect(app).to receive(:call)
 
@@ -29,7 +29,7 @@ describe Routemaster::FaradayMiddleware::Caching do
 
   context 'Without Accept and Accept-Language headers' do
     it 'only calles cache#with_caching with the url' do
-      expect(cache).to receive(:with_caching).with('http://www.example.com/anything').and_yield
+      expect(cache).to receive(:fetch).with('http://www.example.com/anything').and_yield
       expect_any_instance_of(described_class).to receive(:app) { app }
       expect(app).to receive(:call)
 

--- a/spec/routemaster/faraday_middleware/caching_spec.rb
+++ b/spec/routemaster/faraday_middleware/caching_spec.rb
@@ -1,39 +1,93 @@
 require 'spec_helper'
+require 'spec/support/uses_redis'
+require 'spec/support/uses_dotenv'
 require 'faraday'
 require 'routemaster/faraday_middleware/caching'
+require 'routemaster/cache'
 
 describe Routemaster::FaradayMiddleware::Caching do
+  uses_dotenv
+  uses_redis
 
-  let(:cache) { double.as_null_object }
-  let(:app) { double.as_null_object }
-
-  let(:faraday_client) {
-    Faraday.new 'http://www.example.com' do |conn|
-      conn.use Routemaster::FaradayMiddleware::Caching, cache
-    end
+  let(:body) {
+    i = 0
+    -> {
+      i += 1
+      "body #{i}"
+    }
   }
 
-  context 'With supplied Accept and Accept-Language headers' do
-    it 'parses url, version and locale from the request headers and passes \
-    them to cache#fetch' do
-      expect(cache).to receive(:fetch).with('http://www.example.com/anything', version: '1', locale: 'en').and_yield
-      expect_any_instance_of(described_class).to receive(:app) { app }
-      expect(app).to receive(:call)
-
-      faraday_client.get('/anything') do |req|
-        req.headers['Accept'] = "application/json;v=1"
-        req.headers['Accept-Language'] = "en"
-      end
+  let(:stubs) do
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get('/test') { |env| [200, {}, body.call] }
     end
   end
 
-  context 'Without Accept and Accept-Language headers' do
-    it 'only calles cache#with_caching with the url' do
-      expect(cache).to receive(:fetch).with('http://www.example.com/anything').and_yield
-      expect_any_instance_of(described_class).to receive(:app) { app }
-      expect(app).to receive(:call)
-
-      faraday_client.get('/anything')
+  let(:faraday_client) {
+    Faraday.new 'http://www.example.com' do |conn|
+      conn.use Routemaster::FaradayMiddleware::Caching
+      conn.adapter :test, stubs
     end
+  }
+
+  it 'returns a faraday response object' do
+    expect(faraday_client.get('/test')).to be_a Faraday::Response
+  end
+
+  it 'will fetch from the cache for multiple requests to the same endpoint' do
+    expect(faraday_client.get('/test').body).to eq "body 1"
+    expect(faraday_client.get('/test').body).to eq "body 1"
+  end
+
+  it 'will not fetch from the cache for a request with different Accept or Accept-Language headers' do
+      en_v1_1 = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=1"
+        req.headers['Accept-Language'] = "en"
+      end
+
+      en_v1_2 = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=1"
+        req.headers['Accept-Language'] = "en"
+      end
+
+      en_2 = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=2"
+        req.headers['Accept-Language'] = "en"
+      end
+
+      fr_1 = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=1"
+        req.headers['Accept-Language'] = "fr"
+      end
+
+      expect(en_v1_1.body).to eq "body 1"
+      expect(en_v1_2.body).to eq "body 1"
+      expect(en_2.body).to eq "body 2"
+      expect(fr_1.body).to eq "body 3"
+  end
+
+  it 'will cache requests in the same format as Routemaster::Cache' do
+      faraday_resp = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=1"
+        req.headers['Accept-Language'] = "en"
+      end
+      cache_resp = Routemaster::Cache.new.get("http://www.example.com/test", version: 1, locale: 'en')
+
+      expect(faraday_resp.body).to eq "body 1"
+      expect(cache_resp.body).to eq "body 1"
+
+      fetcher = double
+      expect(fetcher).to receive(:get) do
+        Hashie::Mash.new(status: 200, headers: {}, body: body.call)
+      end
+
+      cache_resp = Routemaster::Cache.new(fetcher: fetcher).get("http://www.example.com/test", version: 2, locale: 'en')
+      faraday_resp = faraday_client.get('/test') do |req|
+        req.headers['Accept'] = "application/json;v=2"
+        req.headers['Accept-Language'] = "en"
+      end
+
+      expect(faraday_resp.body).to eq "body 2"
+      expect(cache_resp.body).to eq "body 2"
   end
 end


### PR DESCRIPTION
This is a quick example of a faraday middleware integrated with `Routemaster::Cache`. I'm not sure about the method name `with_caching`, and we need to write some tests/docs if that is to become part of the public interface.

We would include this as part of a stack of middleware that will be responsible for setting version/locale headers and materialisation. So we need to extract redis key information out of the HTTP headers that have been set somewhere up the call chain.