### PR TITLE
LT-113: Allow use of Sidekiq as well as Resque

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem 'dotenv',                     require: false
 gem 'codeclimate-test-reporter',  require: false
 gem 'simplecov'
 gem 'rspec'
+gem 'resque'
+gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       faraday_middleware
       hashie
       net-http-persistent (< 3)
-      rack (~> 1.6.2)
+      rack (>= 1.6.2)
       redis-namespace
       thread
       wisper (~> 1.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       net-http-persistent (< 3)
       rack (~> 1.6.2)
       redis-namespace
-      resque
       thread
       wisper (~> 1.6.1)
 
@@ -21,6 +20,8 @@ GEM
     codeclimate-test-reporter (1.0.3)
       simplecov
     coderay (1.1.1)
+    concurrent-ruby (1.0.2)
+    connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -106,6 +107,11 @@ GEM
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     shellany (0.0.1)
+    sidekiq (4.2.7)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -139,8 +145,10 @@ DEPENDENCIES
   psych
   rack-test
   rake
+  resque
   routemaster-drain!
   rspec
+  sidekiq
   simplecov
   webmock
 

--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -37,6 +37,10 @@ module Routemaster
       end
     end
 
+    def queue_adapter
+      ENV.fetch('ROUTEMASTER_QUEUE_ADAPTER', 'resque').to_sym
+    end
+
     def queue_name
       ENV.fetch('ROUTEMASTER_QUEUE_NAME', 'routemaster')
     end

--- a/lib/routemaster/fetcher.rb
+++ b/lib/routemaster/fetcher.rb
@@ -43,7 +43,7 @@ module Routemaster
     def _connection
       @_connection ||= Faraday.new do |f|
         f.request  :retry, max: 2, interval: 100e-3, backoff_factor: 2
-        f.request  :basic_auth, *_uuid
+        f.basic_auth *_uuid if _uuid
         f.response :mashify
         f.response :json, content_type: /\bjson/
         f.adapter  :net_http_persistent

--- a/lib/routemaster/fetcher.rb
+++ b/lib/routemaster/fetcher.rb
@@ -43,7 +43,7 @@ module Routemaster
     def _connection
       @_connection ||= Faraday.new do |f|
         f.request  :retry, max: 2, interval: 100e-3, backoff_factor: 2
-        f.basic_auth *_uuid if _uuid
+        f.basic_auth(*_uuid) if _uuid
         f.response :mashify
         f.response :json, content_type: /\bjson/
         f.adapter  :net_http_persistent

--- a/lib/routemaster/jobs/backends/resque.rb
+++ b/lib/routemaster/jobs/backends/resque.rb
@@ -10,7 +10,7 @@ module Routemaster
         end
 
         def enqueue(queue, job_class, *args)
-          job_data = data_for(job_class, args)
+          job_data = Job.data_for(job_class, args)
           @adapter.enqueue_to(queue, JobWrapper, job_data)
         end
 

--- a/lib/routemaster/jobs/backends/resque.rb
+++ b/lib/routemaster/jobs/backends/resque.rb
@@ -1,0 +1,17 @@
+require 'resque'
+
+module Routemaster
+  module Jobs
+    module Backends
+      class Resque
+        def initialize(adapter = nil)
+          @adapter = adapter || ::Resque
+        end
+
+        def enqueue(queue, job_class, *args)
+          @adapter.enqueue_to(queue, job_class, *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/routemaster/jobs/backends/resque.rb
+++ b/lib/routemaster/jobs/backends/resque.rb
@@ -1,4 +1,5 @@
 require 'resque'
+require 'routemaster/jobs/job'
 
 module Routemaster
   module Jobs
@@ -9,7 +10,17 @@ module Routemaster
         end
 
         def enqueue(queue, job_class, *args)
-          @adapter.enqueue_to(queue, job_class, *args)
+          job_data = {
+            'class' => job_class.to_s,
+            'args'  => args
+          }
+          @adapter.enqueue_to(queue, JobWrapper, job_data)
+        end
+
+        class JobWrapper
+          def self.perform(job_data)
+            Job.execute(job_data)
+          end
         end
       end
     end

--- a/lib/routemaster/jobs/backends/resque.rb
+++ b/lib/routemaster/jobs/backends/resque.rb
@@ -10,10 +10,7 @@ module Routemaster
         end
 
         def enqueue(queue, job_class, *args)
-          job_data = {
-            'class' => job_class.to_s,
-            'args'  => args
-          }
+          job_data = data_for(job_class, args)
           @adapter.enqueue_to(queue, JobWrapper, job_data)
         end
 

--- a/lib/routemaster/jobs/backends/sidekiq.rb
+++ b/lib/routemaster/jobs/backends/sidekiq.rb
@@ -1,0 +1,17 @@
+require 'sidekiq'
+
+module Routemaster
+  module Jobs
+    module Backends
+      class Sidekiq
+        def initialize(adapter = nil)
+          @adapter = adapter || ::Sidekiq::Client
+        end
+
+        def enqueue(queue, job_class, *args)
+          @adapter.push('queue' => queue, 'class' => job_class, 'args' => args)
+        end
+      end
+    end
+  end
+end

--- a/lib/routemaster/jobs/backends/sidekiq.rb
+++ b/lib/routemaster/jobs/backends/sidekiq.rb
@@ -10,10 +10,7 @@ module Routemaster
         end
 
         def enqueue(queue, job_class, *args)
-          job_data = {
-            'class' => job_class.to_s,
-            'args'  => args
-          }
+          job_data = Job.data_for(job_class, args)
           @adapter.push('queue' => queue, 'class' => JobWrapper, 'args' => [job_data])
         end
 

--- a/lib/routemaster/jobs/backends/sidekiq.rb
+++ b/lib/routemaster/jobs/backends/sidekiq.rb
@@ -1,4 +1,5 @@
 require 'sidekiq'
+require 'routemaster/jobs/job'
 
 module Routemaster
   module Jobs
@@ -9,7 +10,19 @@ module Routemaster
         end
 
         def enqueue(queue, job_class, *args)
-          @adapter.push('queue' => queue, 'class' => job_class, 'args' => args)
+          job_data = {
+            'class' => job_class.to_s,
+            'args'  => args
+          }
+          @adapter.push('queue' => queue, 'class' => JobWrapper, 'args' => [job_data])
+        end
+
+        class JobWrapper
+          include ::Sidekiq::Worker
+
+          def perform(job_data)
+            Job.execute(job_data)
+          end
         end
       end
     end

--- a/lib/routemaster/jobs/cache.rb
+++ b/lib/routemaster/jobs/cache.rb
@@ -4,8 +4,18 @@ module Routemaster
   module Jobs
     # Caches a URL using {Cache}.
     class Cache
+      begin
+        require 'sidekiq'
+        include Sidekiq::Worker
+      rescue LoadError
+      end
+
       def self.perform(url)
         Cache.new.get(url)
+      end
+
+      def perform(url)
+        self.class.perform(url)
       end
     end
   end

--- a/lib/routemaster/jobs/cache.rb
+++ b/lib/routemaster/jobs/cache.rb
@@ -4,8 +4,8 @@ module Routemaster
   module Jobs
     # Caches a URL using {Cache}.
     class Cache
-      def self.perform(url)
-        Cache.new.get(url)
+      def perform(url)
+        Routemaster::Cache.new.get(url)
       end
     end
   end

--- a/lib/routemaster/jobs/cache.rb
+++ b/lib/routemaster/jobs/cache.rb
@@ -4,18 +4,8 @@ module Routemaster
   module Jobs
     # Caches a URL using {Cache}.
     class Cache
-      begin
-        require 'sidekiq'
-        include Sidekiq::Worker
-      rescue LoadError
-      end
-
       def self.perform(url)
         Cache.new.get(url)
-      end
-
-      def perform(url)
-        self.class.perform(url)
       end
     end
   end

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,10 +6,20 @@ module Routemaster
     # Caches a URL using {Cache}, and sweeps the dirty map
     # if sucessful.
     class CacheAndSweep
+      begin
+        require 'sidekiq'
+        include Sidekiq::Worker
+      rescue LoadError
+      end
+
       def self.perform(url)
         Dirty::Map.new.sweep_one(url) do
           Cache.new.get(url)
         end
+      end
+
+      def perform(url)
+        self.class.perform(url)
       end
     end
   end

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,20 +6,10 @@ module Routemaster
     # Caches a URL using {Cache}, and sweeps the dirty map
     # if sucessful.
     class CacheAndSweep
-      begin
-        require 'sidekiq'
-        include Sidekiq::Worker
-      rescue LoadError
-      end
-
       def self.perform(url)
         Dirty::Map.new.sweep_one(url) do
           Cache.new.get(url)
         end
-      end
-
-      def perform(url)
-        self.class.perform(url)
       end
     end
   end

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,7 +6,7 @@ module Routemaster
     # Caches a URL using {Cache}, and sweeps the dirty map
     # if sucessful.
     class CacheAndSweep
-      def self.perform(url)
+      def perform(url)
         Dirty::Map.new.sweep_one(url) do
           Cache.new.get(url)
         end

--- a/lib/routemaster/jobs/client.rb
+++ b/lib/routemaster/jobs/client.rb
@@ -1,0 +1,30 @@
+require 'routemaster/config'
+
+module Routemaster
+  module Jobs
+    class Client
+      extend Forwardable
+
+      def_delegators :@backend, :enqueue
+
+      def initialize(adapter = nil)
+        @backend = build_backend(adapter)
+      end
+
+      private
+
+      def build_backend(adapter)
+        case Config.queue_adapter
+        when :resque
+          require 'routemaster/jobs/backends/resque'
+          Backends::Resque.new(adapter)
+        when :sidekiq
+          require 'routemaster/jobs/backends/sidekiq'
+          Backends::Sidekiq.new(adapter)
+        else
+          raise "Unsupported queue adapter '#{Config.queue_adapter}"
+        end
+      end
+    end
+  end
+end

--- a/lib/routemaster/jobs/job.rb
+++ b/lib/routemaster/jobs/job.rb
@@ -2,6 +2,10 @@ module Routemaster
   module Jobs
     class Job
       class << self
+        def data_for(job_class, args)
+          { 'class' => job_class.to_s, 'args'  => args }
+        end
+
         def execute(job_data)
           job = create_job(job_data)
           job.perform(*job_data['args'])

--- a/lib/routemaster/jobs/job.rb
+++ b/lib/routemaster/jobs/job.rb
@@ -8,7 +8,7 @@ module Routemaster
 
         def execute(job_data)
           job = create_job(job_data)
-          job.perform(*job_data['args'])
+          job.new.perform(*job_data['args'])
         end
 
         private

--- a/lib/routemaster/jobs/job.rb
+++ b/lib/routemaster/jobs/job.rb
@@ -1,0 +1,19 @@
+module Routemaster
+  module Jobs
+    class Job
+      class << self
+        def execute(job_data)
+          job = create_job(job_data)
+          job.perform(*job_data['args'])
+        end
+
+        private
+
+        def create_job(job_data)
+          job_class = job_data['class']
+          Kernel.const_get(job_class)
+        end
+      end
+    end
+  end
+end

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'faraday', '>= 0.9.0'
   spec.add_runtime_dependency     'faraday_middleware'
   spec.add_runtime_dependency     'net-http-persistent', '< 3' # 3.x is currently incompatible with faraday
-  spec.add_runtime_dependency     'rack', '~> 1.6.2'
+  spec.add_runtime_dependency     'rack', '>= 1.6.2'
   spec.add_runtime_dependency     'wisper', '~> 1.6.1'
   spec.add_runtime_dependency     'hashie'
   spec.add_runtime_dependency     'redis-namespace'

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'wisper', '~> 1.6.1'
   spec.add_runtime_dependency     'hashie'
   spec.add_runtime_dependency     'redis-namespace'
-  spec.add_runtime_dependency     'resque'
   spec.add_runtime_dependency     'thread'
 end

--- a/spec/routemaster/drain/caching_spec.rb
+++ b/spec/routemaster/drain/caching_spec.rb
@@ -12,7 +12,7 @@ describe Routemaster::Drain::Caching do
 
   let(:app) { described_class.new }
   let(:listener) { double 'listener' }
-  
+
   before { app.subscribe(listener, prefix: true) }
 
   let(:path)    { '/' }
@@ -40,7 +40,7 @@ describe Routemaster::Drain::Caching do
   end
 
   it 'schedules caching jobs' do
-    expect(Resque).to receive(:enqueue_to).exactly(3).times
+    expect_any_instance_of(Routemaster::Jobs::Client).to receive(:enqueue).exactly(3).times
     perform
   end
 end

--- a/spec/routemaster/jobs/backends/backend_examples.rb
+++ b/spec/routemaster/jobs/backends/backend_examples.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples 'a job backend' do
+  class TestJob
+    def perform(x, y); end
+  end
+
+  let(:job) { TestJob.new }
+  let(:x) { 123 }
+  let(:y) { 'hello' }
+
+  before do
+    allow(TestJob).to receive(:new).and_return(job)
+    allow(job).to receive(:perform).and_call_original
+    described_class.new.enqueue('test_queue', TestJob, x, y)
+  end
+
+  describe '#enqueue' do
+    it 'should execute jobs with a #perform method with the passed arguments' do
+      expect(job).to have_received(:perform).with(x, y)
+    end
+  end
+end

--- a/spec/routemaster/jobs/backends/resque_spec.rb
+++ b/spec/routemaster/jobs/backends/resque_spec.rb
@@ -1,0 +1,16 @@
+require 'routemaster/jobs/backends/resque'
+require 'spec/routemaster/jobs/backends/backend_examples'
+
+RSpec.describe Routemaster::Jobs::Backends::Resque do
+  around do |example|
+    original_inline = Resque.inline
+    begin
+      Resque.inline = true
+      example.run
+    ensure
+      Resque.inline = original_inline
+    end
+  end
+
+  it_behaves_like 'a job backend'
+end

--- a/spec/routemaster/jobs/backends/sidekiq_spec.rb
+++ b/spec/routemaster/jobs/backends/sidekiq_spec.rb
@@ -1,0 +1,11 @@
+require 'sidekiq/testing'
+require 'routemaster/jobs/backends/sidekiq'
+require 'spec/routemaster/jobs/backends/backend_examples'
+
+RSpec.describe Routemaster::Jobs::Backends::Sidekiq do
+  around do |example|
+    Sidekiq::Testing.inline! { example.run }
+  end
+
+  it_behaves_like 'a job backend'
+end

--- a/spec/routemaster/jobs/client_spec.rb
+++ b/spec/routemaster/jobs/client_spec.rb
@@ -1,0 +1,46 @@
+require 'routemaster/jobs/client'
+require 'routemaster/jobs/cache_and_sweep'
+
+RSpec.describe Routemaster::Jobs::Client do
+  let(:client) { Routemaster::Jobs::Client.new(adapter) }
+
+  let(:perform) do
+    client.enqueue('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1')
+  end
+
+  describe '#enqueue' do
+    before do
+      allow(Routemaster::Config).to receive(:queue_adapter).and_return(backend)
+      allow(client).to receive(:enqueue).and_call_original
+    end
+
+     context 'when the backend is Resque' do
+      let(:backend) { :resque }
+      let(:adapter) { double('Resque', enqueue_to: nil) }
+
+      it 'queues a Resque fetch job' do
+        expect(adapter).to receive(:enqueue_to).with(
+          'routemaster',
+          Routemaster::Jobs::CacheAndSweep,
+          'https://example.com/1')
+        perform
+      end
+    end
+
+    context 'when the backend is Sidekiq' do
+      let(:backend) { :sidekiq }
+      let(:adapter) { double('Sidekiq', push: nil) }
+
+      it 'queues a Sidekiq fetch job' do
+        expect(adapter).to receive(:push).with(
+          'queue' => 'routemaster',
+          'class' => Routemaster::Jobs::CacheAndSweep,
+          'args' => ['https://example.com/1'])
+        perform
+      end
+    end
+  end
+end
+
+
+

--- a/spec/routemaster/jobs/client_spec.rb
+++ b/spec/routemaster/jobs/client_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Routemaster::Jobs::Client do
       it 'queues a Resque fetch job' do
         expect(adapter).to receive(:enqueue_to).with(
           'routemaster',
-          Routemaster::Jobs::CacheAndSweep,
-          'https://example.com/1')
+          Routemaster::Jobs::Backends::Resque::JobWrapper,
+          { 'class' => 'Routemaster::Jobs::CacheAndSweep', 'args' => ['https://example.com/1'] })
         perform
       end
     end
@@ -34,8 +34,8 @@ RSpec.describe Routemaster::Jobs::Client do
       it 'queues a Sidekiq fetch job' do
         expect(adapter).to receive(:push).with(
           'queue' => 'routemaster',
-          'class' => Routemaster::Jobs::CacheAndSweep,
-          'args' => ['https://example.com/1'])
+          'class' => Routemaster::Jobs::Backends::Sidekiq::JobWrapper,
+          'args' => [{ 'class' => 'Routemaster::Jobs::CacheAndSweep', 'args' => ['https://example.com/1'] }])
         perform
       end
     end

--- a/spec/routemaster/middleware/cache_spec.rb
+++ b/spec/routemaster/middleware/cache_spec.rb
@@ -2,30 +2,29 @@ require 'spec_helper'
 require 'spec/support/rack_test'
 require 'routemaster/middleware/cache'
 
-describe Routemaster::Middleware::Cache do
- 
+RSpec.describe Routemaster::Middleware::Cache do
   # busts the cache for each dirty url
 
   let(:terminator) { ErrorRackApp.new }
   let(:app) { described_class.new(terminator, **options) }
-  let(:resque) { double 'resque', enqueue_to: nil }
-  let(:cache) { double 'cache', bust: nil }
-  let(:options) {{ cache: cache, resque: resque }}
-  
+  let(:client) { Routemaster::Jobs::Client.new }
+  let(:cache) { instance_double(Routemaster::Cache, bust: nil) }
+  let(:options) {{ cache: cache, client: client }}
+
   let(:perform) do
     post '/whatever', '', 'routemaster.dirty' => payload
   end
 
   describe '#call' do
     let(:payload) { ['https://example.com/1'] }
-    
+
     it 'busts the cache' do
       expect(cache).to receive(:bust).with(payload.first)
       perform
     end
 
     it 'queues a fetch job' do
-      expect(resque).to receive(:enqueue_to).with('routemaster', anything, 'https://example.com/1')
+      expect(client).to receive(:enqueue).with('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1')
       perform
     end
   end


### PR DESCRIPTION
*Still TODO: Update the docs to indicate either Sidekiq or Resque can be used, and add some more test coverage.*

This PR allows use of different job engine backends, with either Sidekiq or Resque supported. It's a bit "involved" seeing as it was sticking to the following constraints:

* Don't just dump Resque support as we still use it in some projects
* Don't use ActiveJob as some projects are still on Rails 3.x

As such it takes the approach of using an "ActiveJob-lite" style pluggable backend, just reimplementing the parts that are needed.

The default is still Resque, so it's almost entirely backwards compatible. The only slight incompatibility is that the job backend initializer will need to include the line of code to preload the relevant job bits, e.g.

```ruby
# config/initializers/routemaster.rb

require 'routemaster/jobs/backends/sidekiq'
```