### PR TITLE
SUPP-2718: Add delete method to API client

### DIFF
--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -49,6 +49,16 @@ module Routemaster
       end
     end
 
+    def delete(url, headers: {})
+      host = URI.parse(url).host
+      response_wrapper do
+        connection.delete do |req|
+          req.url url
+          req.headers = headers.merge(auth_header(host))
+        end
+      end
+    end
+
     def discover(url)
       get(url)
     end

--- a/lib/routemaster/cache.rb
+++ b/lib/routemaster/cache.rb
@@ -61,7 +61,7 @@ module Routemaster
     end
 
     def initialize(redis:nil, client:nil)
-      @redis   = redis || Config.cache_redis
+      @redis  = redis || Config.cache_redis
       @client = client || APIClient.new(listener: self)
     end
 

--- a/lib/routemaster/middleware/response_caching.rb
+++ b/lib/routemaster/middleware/response_caching.rb
@@ -16,7 +16,7 @@ module Routemaster
       end
 
       def call(env)
-        @cache.del(cache_key(env)) if env.method == :patch
+        @cache.del(cache_key(env)) if %i(patch delete).include?(env.method)
         return @app.call(env) if env.method != :get
 
         fetch_from_cache(env) || fetch_from_service(env)

--- a/lib/routemaster/resources/rest_resource.rb
+++ b/lib/routemaster/resources/rest_resource.rb
@@ -25,6 +25,10 @@ module Routemaster
       def update(id=nil, params)
         @client.patch(@url.gsub('{id}', id.to_s), body: params)
       end
+
+      def destroy(id=nil)
+        @client.delete(@url.gsub('{id}', id.to_s))
+      end
     end
   end
 end

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -107,4 +107,25 @@ RSpec.describe 'Api client integration specs' do
       end
     end
   end
+
+  describe 'DELETE request' do
+    let(:body_cache_keys) { ["cache:#{url}", "v:,l:,body"] }
+    let(:headers_cache_keys) { ["cache:#{url}", "v:,l:,headers"] }
+    let(:url) { "#{host}/success" }
+
+    context 'when there is a previous cached resource' do
+      before { subject.get(url) }
+      let(:cache) { Routemaster::Config.cache_redis }
+
+      it 'invalidates the cache on destroy' do
+        expect(cache.hget("cache:#{url}", "v:,l:,body")).to be
+        subject.delete(url)
+
+        expect(cache.hget("cache:#{url}", "v:,l:,body")).to be_nil
+
+        subject.get(url)
+        expect(cache.hget("cache:#{url}", "v:,l:,body")).to be
+      end
+    end
+  end
 end

--- a/spec/routemaster/resources/rest_resource_spec.rb
+++ b/spec/routemaster/resources/rest_resource_spec.rb
@@ -32,9 +32,16 @@ module Routemaster
       end
 
       describe '#update' do
-        it 'gets to the given url' do
+        it 'updates the given resource' do
           expect(client).to receive(:patch).with(url, body: params)
           subject.update(1, params)
+        end
+      end
+
+      describe '#destroy' do
+        it 'destroys the given resource' do
+          expect(client).to receive(:delete).with(url)
+          subject.destroy(1)
         end
       end
     end


### PR DESCRIPTION
JIRA Ticket: https://deliveroo.atlassian.net/browse/SUPP-2718

## Why

As we'll need to destroy user (rider) sessions from Orderweb as part of the new authentication flow, we need the rest resource class and the underlying client to support delete requests. 