### PR TITLE
Better API Client errors

### DIFF
--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -9,7 +9,7 @@ module Routemaster
       end
 
       def errors
-        body['errors']
+        body.fetch('errors', {})
       end
 
       def message
@@ -27,44 +27,44 @@ module Routemaster
       end
     end
 
-    class UnauthorizedResourceAccessError < BaseError
+    class UnauthorizedResourceAccess < BaseError
       def message
         "Unauthorized Resource Access Error"
       end
     end
 
-    class InvalidResourceError < BaseError
+    class InvalidResource < BaseError
       def message
         "Invalid Resource Error"
       end
     end
 
-    class ResourceNotFoundError < BaseError
+    class ResourceNotFound < BaseError
       def message
         "Resource Not Found Error"
       end
     end
 
-    class FatalResourceError < BaseError
+    class FatalResource < BaseError
       def message
         "Fatal Resource Error. body: #{body}, url: #{env.url}, method: #{env.method}"
       end
     end
 
-    class ConflictResourceError < BaseError
+    class ConflictResource < BaseError
       def message
         "ConflictResourceError Resource Error"
       end
     end
 
-    class IncompatibleVersionError < BaseError
+    class IncompatibleVersion < BaseError
       def message
         headers = env.request_headers.select { |k, _| k != 'Authorization' }
         "Incompatible Version Error. headers: #{headers}, url: #{env.url}, method: #{env.method}"
       end
     end
 
-    class ResourceThrottlingError < BaseError
+    class ResourceThrottling < BaseError
       def message
         "Resource Throttling Error"
       end

--- a/lib/routemaster/middleware/error_handling.rb
+++ b/lib/routemaster/middleware/error_handling.rb
@@ -5,15 +5,15 @@ module Routemaster
   module Middleware
     class ErrorHandling < Faraday::Response::Middleware
       ERRORS_MAPPING = {
-        (400..400) => Errors::InvalidResourceError,
-        (401..401) => Errors::UnauthorizedResourceAccessError,
-        (403..403) => Errors::UnauthorizedResourceAccessError,
-        (404..404) => Errors::ResourceNotFoundError,
-        (409..409) => Errors::ConflictResourceError,
-        (412..412) => Errors::IncompatibleVersionError,
-        (413..413) => Errors::InvalidResourceError,
-        (429..429) => Errors::ResourceThrottlingError,
-        (407..500) => Errors::FatalResourceError
+        (400..400) => Errors::InvalidResource,
+        (401..401) => Errors::UnauthorizedResourceAccess,
+        (403..403) => Errors::UnauthorizedResourceAccess,
+        (404..404) => Errors::ResourceNotFound,
+        (409..409) => Errors::ConflictResource,
+        (412..412) => Errors::IncompatibleVersion,
+        (413..413) => Errors::InvalidResource,
+        (429..429) => Errors::ResourceThrottling,
+        (407..500) => Errors::FatalResource
       }.freeze
 
       def on_complete(env)

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -51,39 +51,39 @@ RSpec.describe 'Api client integration specs' do
 
   describe 'error handling' do
     it 'raises an ResourceNotFoundError on 404' do
-      expect { subject.get(host + '/404') }.to raise_error(Routemaster::Errors::ResourceNotFoundError)
+      expect { subject.get(host + '/404') }.to raise_error(Routemaster::Errors::ResourceNotFound)
     end
 
     it 'raises an InvalidResourceError on 400' do
-      expect { subject.get(host + '/400') }.to raise_error(Routemaster::Errors::InvalidResourceError)
+      expect { subject.get(host + '/400') }.to raise_error(Routemaster::Errors::InvalidResource)
     end
 
     it 'raises an UnauthorizedResourceAccessError on 401' do
-      expect { subject.get(host + '/401') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccessError)
+      expect { subject.get(host + '/401') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccess)
     end
 
     it 'raises an UnauthorizedResourceAccessError on 403' do
-      expect { subject.get(host + '/403') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccessError)
+      expect { subject.get(host + '/403') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccess)
     end
 
     it 'raises an ConflictResourceError on 409' do
-      expect { subject.get(host + '/409') }.to raise_error(Routemaster::Errors::ConflictResourceError)
+      expect { subject.get(host + '/409') }.to raise_error(Routemaster::Errors::ConflictResource)
     end
 
     it 'raises an IncompatibleVersionError on 412' do
-      expect { subject.get(host + '/412') }.to raise_error(Routemaster::Errors::IncompatibleVersionError)
+      expect { subject.get(host + '/412') }.to raise_error(Routemaster::Errors::IncompatibleVersion)
     end
 
     it 'raises an InvalidResourceError on 413' do
-      expect { subject.get(host + '/413') }.to raise_error(Routemaster::Errors::InvalidResourceError)
+      expect { subject.get(host + '/413') }.to raise_error(Routemaster::Errors::InvalidResource)
     end
 
     it 'raises an ResourceThrottlingError on 429' do
-      expect { subject.get(host + '/429') }.to raise_error(Routemaster::Errors::ResourceThrottlingError)
+      expect { subject.get(host + '/429') }.to raise_error(Routemaster::Errors::ResourceThrottling)
     end
 
     it 'raises an FatalResourceError on 500' do
-      expect { subject.get(host + '/500') }.to raise_error(Routemaster::Errors::FatalResourceError)
+      expect { subject.get(host + '/500') }.to raise_error(Routemaster::Errors::FatalResource)
     end
   end
 

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -50,39 +50,39 @@ RSpec.describe 'Api client integration specs' do
   let(:host) { 'http://localhost:8000' }
 
   describe 'error handling' do
-    it 'raises an ResourceNotFoundError on 404' do
+    it 'raises an ResourceNotFound on 404' do
       expect { subject.get(host + '/404') }.to raise_error(Routemaster::Errors::ResourceNotFound)
     end
 
-    it 'raises an InvalidResourceError on 400' do
+    it 'raises an InvalidResource on 400' do
       expect { subject.get(host + '/400') }.to raise_error(Routemaster::Errors::InvalidResource)
     end
 
-    it 'raises an UnauthorizedResourceAccessError on 401' do
+    it 'raises an UnauthorizedResourceAccess on 401' do
       expect { subject.get(host + '/401') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccess)
     end
 
-    it 'raises an UnauthorizedResourceAccessError on 403' do
+    it 'raises an UnauthorizedResourceAccess on 403' do
       expect { subject.get(host + '/403') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccess)
     end
 
-    it 'raises an ConflictResourceError on 409' do
+    it 'raises an ConflictResource on 409' do
       expect { subject.get(host + '/409') }.to raise_error(Routemaster::Errors::ConflictResource)
     end
 
-    it 'raises an IncompatibleVersionError on 412' do
+    it 'raises an IncompatibleVersion on 412' do
       expect { subject.get(host + '/412') }.to raise_error(Routemaster::Errors::IncompatibleVersion)
     end
 
-    it 'raises an InvalidResourceError on 413' do
+    it 'raises an InvalidResource on 413' do
       expect { subject.get(host + '/413') }.to raise_error(Routemaster::Errors::InvalidResource)
     end
 
-    it 'raises an ResourceThrottlingError on 429' do
+    it 'raises an ResourceThrottling on 429' do
       expect { subject.get(host + '/429') }.to raise_error(Routemaster::Errors::ResourceThrottling)
     end
 
-    it 'raises an FatalResourceError on 500' do
+    it 'raises an FatalResource on 500' do
       expect { subject.get(host + '/500') }.to raise_error(Routemaster::Errors::FatalResource)
     end
   end


### PR DESCRIPTION
- Use #fetch instead of brackets to fall back to default
- Remove -Error from error class names.