### PR TITLE
Define Hateoas Response methods at instance level

### DIFF
--- a/lib/routemaster/responses/hateoas_response.rb
+++ b/lib/routemaster/responses/hateoas_response.rb
@@ -26,7 +26,7 @@ module Routemaster
           unless respond_to?(method_name)
             resource = Resources::RestResource.new(_links[normalized_method_name]['href'], client: @client)
 
-            self.class.send(:define_method, method_name) do |*m_args|
+            define_singleton_method(method_name) do |*m_args|
               resource
             end
 


### PR DESCRIPTION
## What

.define_method adds the method definition to the Class itself rather than the single instance. #define_singleton_method fixes the problem and defines the method at instance level.