### PR TITLE
Ip 483/promise for fget

### DIFF
--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -7,7 +7,7 @@ require 'routemaster/config'
 require 'routemaster/middleware/response_caching'
 require 'routemaster/middleware/error_handling'
 require 'routemaster/middleware/metrics'
-require 'routemaster/responses/future_response'
+require 'routemaster/responses/response_promise'
 
 # Loading the Faraday adapter for Typhoeus requires a little dance
 require 'faraday/adapter/typhoeus'
@@ -58,7 +58,7 @@ module Routemaster
     # Same as {{get}}, except with 
     def fget(url, **options)
       uri = _assert_uri(url)
-      Responses::FutureResponse.new { get(uri, options) }
+      Responses::ResponsePromise.new { get(uri, options) }
     end
 
     def post(url, body: {}, headers: {})

--- a/lib/routemaster/cache.rb
+++ b/lib/routemaster/cache.rb
@@ -55,7 +55,7 @@ module Routemaster
     # Like {#get}, but schedules any request in the background using a thread
     # pool. Handy to issue lots of requests in parallel.
     #
-    # @return [FutureResponse], which responds to `status`, `headers`, and `body`
+    # @return [ResponsePromise], which responds to `status`, `headers`, and `body`
     # like [Response].
     def fget(url, version: nil, locale: nil)
       @client.fget(url, headers: headers(version: version, locale: locale))

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -158,7 +158,7 @@ describe Routemaster::APIClient do
         expect { perform.(host + '/500') }.to raise_error(Routemaster::Errors::FatalResource)
       end
     end
-  
+
     describe '#get' do
       let(:perform) { ->(uri) { subject.get(uri) } }
       include_examples 'exception raiser'

--- a/spec/routemaster/responses/hateoas_enumerable_response_spec.rb
+++ b/spec/routemaster/responses/hateoas_enumerable_response_spec.rb
@@ -59,7 +59,7 @@ describe Routemaster::Responses::HateoasEnumerableResponse do
   subject { described_class.new(client.get(index_url)) }
 
   # so we don't pollute future specs with pending requests:
-  after { Routemaster::Responses::FutureResponse::Pool.reset }
+  after { Routemaster::Responses::ResponsePromise::Pool.reset }
 
   describe '#each' do
     it 'is enumerable' do

--- a/spec/routemaster/responses/response_promise_spec.rb
+++ b/spec/routemaster/responses/response_promise_spec.rb
@@ -10,6 +10,14 @@ describe Routemaster::Responses::ResponsePromise do
     end
   end
 
+  it "is chainable" do
+    passing_spy = spy('passing spy')
+    future = described_class.new {}
+    future.on_success { passing_spy.on_success }
+    future.value
+    expect(passing_spy).to have_received(:on_success)
+  end
+
   it 're-raises exceptions' do
     future = described_class.new { raise 'foobar' }
 

--- a/spec/routemaster/responses/response_promise_spec.rb
+++ b/spec/routemaster/responses/response_promise_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'hashie/mash'
-require 'routemaster/responses/future_response'
+require 'routemaster/responses/response_promise'
 
-describe Routemaster::Responses::FutureResponse do
+describe Routemaster::Responses::ResponsePromise do
   %i[status headers body].each do |method|
     it "passes through '#{method}'" do
       future = described_class.new { Hashie::Mash.new(method => 'foobar') }


### PR DESCRIPTION
This PR:

- FutureResponse -> ResponsePromise
- ResponsePromise is a subclass of Concurrent::Promise, this allows us to chain calls like `on_error` onto the promise
- maintains the blocking `header`, `body` calls