### PR TITLE
Memoize root resources at class level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Bug fixes:
+
+- APIClient#discover now memoizes the root response at class level (#35)
+
 ### 2.4.1 (2017-03-15)
 
 Features:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -25,16 +25,22 @@ require 'hashie/mash'
 
 module Routemaster
   class APIClient
+
+    # Memoize the root resources at Class level so that we don't hit the cache
+    # all the time to fetch the root resource before doing anything else.
+    @@root_resources = {}
+
     def initialize(middlewares: [],
                    listener: nil,
                    response_class: nil,
                    metrics_client: nil,
                    source_peer: nil)
-      @listener = listener
-      @middlewares = middlewares
+
+      @listener       = listener
+      @middlewares    = middlewares
       @response_class = response_class
       @metrics_client = metrics_client
-      @source_peer = source_peer
+      @source_peer    = source_peer
 
       connection # warm up connection so Faraday does all it's magical file loading in the main thread
     end
@@ -74,7 +80,7 @@ module Routemaster
     end
 
     def discover(url)
-      get(url)
+      @@root_resources[url] ||= get(url)
     end
 
     def with_response(response_class)


### PR DESCRIPTION
## Why

The cached response of the `root` resources is being hit way more frequently than other resources, thus always hitting the same node on Redis.

![screen shot 2017-03-16 at 17 01 07](https://cloud.githubusercontent.com/assets/7835873/24008666/30bde3c6-0a6a-11e7-8448-f023f06953da.png)

## What

Memoize the root resource responses at class level (by `url => response`) in order to avoid hitting the same key on a single node. This will (probably) bring the affected shard back to in line with others. 

The downside is that in order to fetch the updated root resources we'll need to restart whichever application is using the `drain`.