### PR TITLE
Require rest_resource file further up in the file tree (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Bug fixes:
+
+- Require 'rest_resource' further up in the file tree (#36)
+
 ### 2.4.2 (2017-03-21)
 
 Bug fixes:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -9,6 +9,10 @@ require 'routemaster/middleware/error_handling'
 require 'routemaster/middleware/metrics'
 require 'routemaster/responses/response_promise'
 
+# This is not a direct dependency, we need to load it early to prevent a
+# circular dependency in hateoas_response.rb
+require 'routemaster/resources/rest_resource'
+
 # Loading the Faraday adapter for Typhoeus requires a little dance
 require 'faraday/adapter/typhoeus'
 require 'typhoeus/adapters/faraday'

--- a/lib/routemaster/responses/hateoas_response.rb
+++ b/lib/routemaster/responses/hateoas_response.rb
@@ -2,10 +2,6 @@ require 'core_ext/forwardable'
 require 'forwardable'
 require 'routemaster/api_client'
 
-# While this depends on `RestResource`, we can't laod it as there is a circular
-# dependency.
-# require 'routemaster/resources/rest_resource'
-
 module Routemaster
   module Responses
     class HateoasResponse


### PR DESCRIPTION
## Why

Removing the `require 'routemaster/resources/rest_resource'` line from `hateoas_response.rb` fixed a circular dependency, but as the file is not required anywhere else, ruby doesn't know where `Resources::RestResource` is coming from.

## What

Require the file in `routemaster/api_client.rb`, a file which is needed by both files affected by the circular dependency (`hateoas_response` and `rest_resource`).