### PR TITLE
Optionally wrap the APIClient actions inside a Response class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Features:
+
+- Optionally wrap the APIClient actions inside a Response class (#37)
+
 ### 2.4.3 (2017-03-22)
 
 Bug fixes:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -72,11 +72,19 @@ module Routemaster
     end
 
     def post(url, body: {}, headers: {})
-      _request(:post, url: url, body: body, headers: headers)
+      _wrapped_response _request(
+        :post,
+        url: url,
+        body: body,
+        headers: headers)
     end
 
     def patch(url, body: {}, headers: {})
-      _request(:patch, url: url, body: body, headers: headers)
+      _wrapped_response _request(
+        :patch,
+        url: url,
+        body: body,
+        headers: headers)
     end
 
     def delete(url, headers: {})

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -55,9 +55,19 @@ describe Routemaster::APIClient do
         expect(req.headers).to include('X-Custom-Header')
       end
     end
+  end
 
+  shared_examples 'a wrappable response' do
     context 'when response_class is present' do
       before do
+        @req = stub_request(:get, /example\.com/).to_return(
+          status:   200,
+          body:     { id: 132, type: 'widget' }.to_json,
+          headers:  {
+            'content-type' => 'application/json;v=1'
+          }
+        )
+
         class DummyResponse
           def initialize(res, client: nil); end
           def dummy; true; end
@@ -75,11 +85,13 @@ describe Routemaster::APIClient do
   describe '#get' do
     subject { fetcher.get(url, headers: headers) }
     it_behaves_like 'a GET requester'
+    it_behaves_like 'a wrappable response'
   end
 
   describe '#fget' do
     subject { fetcher.fget(url, headers: headers) }
     it_behaves_like 'a GET requester'
+    it_behaves_like 'a wrappable response'
 
     context "when setting callbacks" do
       before do
@@ -147,6 +159,8 @@ describe Routemaster::APIClient do
       subject
       expect(@post_req).to have_been_requested
     end
+
+    it_behaves_like 'a wrappable response'
   end
 
   describe '#patch' do
@@ -166,6 +180,8 @@ describe Routemaster::APIClient do
       subject
       expect(@patch_req).to have_been_requested
     end
+
+    it_behaves_like 'a wrappable response'
   end
 
   describe '#delete' do


### PR DESCRIPTION
## Why

The `#post`, `#patch` and `#delete` methods return a `Faraday::Response` since 2.4.0 even after wrapping the HTTP request inside the `with_response` block. This causes some specs on `orderweb` to fail, as it was expecting a `HateoasResponse` back from those actions.

## What

Wrap the methods (except #delete) inside `@response_class` if provided by using `_wrapped_response` method.