### PR TITLE
LT-436/Siphon Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Unreleased
+
+Features:
+
+- Adds the Siphon middleware
+
+
 ### 2.4.4 (2017-03-27)
 
 Features:

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -1,0 +1,28 @@
+module Routemaster
+  module Middleware
+    class Siphon
+      # Filters out events based on their topic and passes them to a handling class
+      # Usage:
+      #    use Middleware::Siphon, 'some_topic' => SomeTopicSeriesBuilder
+      def initialize(app, processors)
+        @app = app
+        @processors = processors
+      end
+
+      def topics_to_avoid
+        @processors.keys
+      end
+
+      def call(env)
+        time_series, payloads = env.fetch('routemaster.payload', []).partition do |event|
+          topics_to_avoid.include? event['topic']
+        end
+        time_series.each do |event|
+          @processors[event['topic']].new(event).call
+        end
+        env['routemaster.payload'] = payloads
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -3,25 +3,27 @@ module Routemaster
     class Siphon
       # Filters out events based on their topic and passes them to a handling class
       # Usage:
-      #    use Middleware::Siphon, 'some_topic' => SomeTopicSeriesBuilder
+      #    use Middleware::Siphon, 'some_topic' => SomeTopicHandler
       def initialize(app, processors)
         @app = app
         @processors = processors
       end
 
-      def topics_to_avoid
-        @processors.keys
-      end
-
       def call(env)
-        time_series, payloads = env.fetch('routemaster.payload', []).partition do |event|
-          topics_to_avoid.include? event['topic']
+        siphoned, non_siphoned = env.fetch('routemaster.payload', []).partition do |event|
+          topics_to_siphon.include? event['topic']
         end
-        time_series.each do |event|
+        siphoned.each do |event|
           @processors[event['topic']].new(event).call
         end
-        env['routemaster.payload'] = payloads
+        env['routemaster.payload'] = non_siphoned
         @app.call(env)
+      end
+
+      private
+
+      def topics_to_siphon
+        @topics_to_siphon ||= @processors.keys
       end
     end
   end

--- a/spec/routemaster/middleware/root_post_only_spec.rb
+++ b/spec/routemaster/middleware/root_post_only_spec.rb
@@ -40,7 +40,3 @@ describe Routemaster::Middleware::RootPostOnly do
     end
   end
 end
-
-
-
-

--- a/spec/routemaster/middleware/siphon_spec.rb
+++ b/spec/routemaster/middleware/siphon_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'spec/support/rack_test'
+require 'spec/support/events'
+require 'routemaster/middleware/siphon'
+require 'json'
+
+describe Routemaster::Middleware::Siphon do
+  let(:terminator) { ErrorRackApp.new }
+  let(:app) { described_class.new(terminator, options) }
+
+  let(:perform) do
+    post '/whatever', '', 'routemaster.payload' => payload
+  end
+
+  describe '#call' do
+
+    let(:options) { { filter:filter } }
+    let(:payload) { [ make_event(1), make_event(1).merge({'topic' => 'notstuff'})] }
+
+    context "if no siphon is defined" do
+      let(:options){ {} }
+      it "passes all to the terminator"  do
+        perform
+        expect(terminator.last_env['routemaster.payload']).to eq payload
+      end
+    end
+
+    context "if a 'stuff' syphon is defined" do
+      let(:syphon_double){
+        double(new: syphon_instance)
+      }
+      let(:syphon_instance){
+        double(call: nil)
+      }
+      let(:options){ { 'stuff' => syphon_double } }
+
+      it "calls the syphon with the event" do
+        perform
+        expect(syphon_double).to have_received(:new).with(payload[0])
+        expect(syphon_instance).to have_received(:call)
+      end
+
+      it "passes 'notstuff' to the terminator"  do
+        perform
+        expect(terminator.last_env['routemaster.payload']).to eq [payload[1]]
+      end
+    end
+  end
+end

--- a/spec/routemaster/middleware/siphon_spec.rb
+++ b/spec/routemaster/middleware/siphon_spec.rb
@@ -18,26 +18,23 @@ describe Routemaster::Middleware::Siphon do
     let(:payload) { [ make_event(1), make_event(1).merge({'topic' => 'notstuff'})] }
 
     context "if no siphon is defined" do
-      let(:options){ {} }
+      let(:options) { {} }
+
       it "passes all to the terminator"  do
         perform
         expect(terminator.last_env['routemaster.payload']).to eq payload
       end
     end
 
-    context "if a 'stuff' syphon is defined" do
-      let(:syphon_double){
-        double(new: syphon_instance)
-      }
-      let(:syphon_instance){
-        double(call: nil)
-      }
-      let(:options){ { 'stuff' => syphon_double } }
+    context "if a 'stuff' siphon is defined" do
+      let(:siphon_double) { double(new: siphon_instance) }
+      let(:siphon_instance) { double(call: nil) }
+      let(:options){ { 'stuff' => siphon_double } }
 
-      it "calls the syphon with the event" do
+      it "calls the siphon with the event" do
         perform
-        expect(syphon_double).to have_received(:new).with(payload[0])
-        expect(syphon_instance).to have_received(:call)
+        expect(siphon_double).to have_received(:new).with(payload[0])
+        expect(siphon_instance).to have_received(:call)
       end
 
       it "passes 'notstuff' to the terminator"  do


### PR DESCRIPTION
This Pr adds a siphon middleware. We're using this for building time series data for rider locations and thought it might be useful generally.