### PR TITLE
LT-437/cache-expire-drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 Features:
 
 - Adds the Siphon middleware
+- Adds CacheBusting Middleware
 
+Bug fixes:
+
+- Caching middleware always busts the cache on events - preventing stale events being cached in some circumstances
 
 ### 2.4.4 (2017-03-27)
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ response = @cache.fget('https://example.com/widgets/123')
 puts response.body.id
 ```
 
-In this example, is your app was notified by Routemaster about Widget #123, the
+In this example, if your app was notified by Routemaster about Widget #123, the
 cache will be very likely to be hit; and it will be invalidated automatically
 whenever the drain gets notified about a change on that widget.
 
@@ -209,6 +209,17 @@ and have any `HTTP GET` requests (and cache queries) happen in parallel.
 See
 [rubydoc](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Cache)
 for more details on `Cache`.
+
+### Expire Cache data for all notified resources
+
+You may wish to maintain a coherent cache but don't need the cache to be warmed
+before you process incoming events. In that case, use the cache as detailed above
+but swap the `Caching` drain out for `CachingBusting`
+
+```ruby
+require 'routemaster/drain/machine'
+$app = Routemaster::Drain::CachingBusting.new
+```
 
 ## HTTP Client
 The Drain is using a Faraday http client for communication between services. The client
@@ -326,4 +337,3 @@ as in `Receiver::Filter` for instance.
 Do not bump version numbers on branches (a maintainer will do this when cutting
 a release); but please do describe your changes in the `CHANGELOG` (at the top,
 without a version number).
-

--- a/lib/routemaster/drain/cache_busting.rb
+++ b/lib/routemaster/drain/cache_busting.rb
@@ -16,7 +16,7 @@ module Routemaster
     # See the various corresponding middleware for details on operation:
     # {Middleware::RootPostOnly}, {Middleware::Authenticate},
     # {Middleware::Parse}, {Middleware::ExpireCache} and {Terminator}.
-    class ExpiringCache
+    class CacheBusting
       extend Forwardable
 
       def initialize(options = {})

--- a/lib/routemaster/drain/expiring_cache.rb
+++ b/lib/routemaster/drain/expiring_cache.rb
@@ -1,26 +1,22 @@
 require 'routemaster/middleware/root_post_only'
 require 'routemaster/middleware/authenticate'
 require 'routemaster/middleware/parse'
-require 'routemaster/middleware/filter'
-require 'routemaster/middleware/dirty'
-require 'routemaster/middleware/cache'
 require 'routemaster/middleware/expire_cache'
+require 'routemaster/middleware/payload_filter'
+require 'routemaster/middleware/filter'
 require 'routemaster/drain/terminator'
 require 'rack/builder'
 require 'delegate'
 
 module Routemaster
   module Drain
-    # Rack application which authenticates, parses, filters, pushes to a dirty map,
-    # busts cache, schedules preemptive caching, and finally broadcasts events
-    # received from Routemaster.
+    # Rack application which authenticates, parses, filters duplicates in this request
+    # and invalidates the cache for all updated or new items.
     #
     # See the various corresponding middleware for details on operation:
     # {Middleware::RootPostOnly}, {Middleware::Authenticate},
-    # {Middleware::Parse}, {Middleware::Filter}, {Middleware::Dirty},
-    # {Middleware::Cache} and {Terminator}.
-    #
-    class Caching
+    # {Middleware::Parse}, {Middleware::ExpireCache} and {Terminator}.
+    class ExpiringCache
       extend Forwardable
 
       def initialize(options = {})
@@ -29,10 +25,8 @@ module Routemaster
           use Middleware::RootPostOnly
           use Middleware::Authenticate, options
           use Middleware::Parse
-          use Middleware::ExpireCache,  options
-          use Middleware::Filter,       options
-          use Middleware::Dirty,        options
-          use Middleware::Cache,        options
+          use Middleware::Filter, { filter: Routemaster::Middleware::PayloadFilter.new }.merge(options)
+          use Middleware::ExpireCache
           run terminator
         end
       end

--- a/lib/routemaster/middleware/cache.rb
+++ b/lib/routemaster/middleware/cache.rb
@@ -16,7 +16,6 @@ module Routemaster
 
       def call(env)
         env.fetch('routemaster.dirty', []).each do |url|
-          @cache.invalidate(url)
           @client.enqueue(@queue, Routemaster::Jobs::CacheAndSweep, url)
         end
         @app.call(env)

--- a/lib/routemaster/middleware/expire_cache.rb
+++ b/lib/routemaster/middleware/expire_cache.rb
@@ -1,0 +1,20 @@
+require 'routemaster/cache'
+
+module Routemaster
+  module Middleware
+    class ExpireCache
+      def initialize(app, cache:nil)
+        @app    = app
+        @cache  = cache || Routemaster::Cache.new
+      end
+
+      def call(env)
+        env.fetch('routemaster.payload', []).each do |event|
+          next if event['type'] == 'noop'
+          @cache.invalidate(event['url'])
+        end
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/routemaster/middleware/payload_filter.rb
+++ b/lib/routemaster/middleware/payload_filter.rb
@@ -1,0 +1,10 @@
+module Routemaster
+  module Middleware
+    class PayloadFilter
+      # Filters duplicate events by url and type in a single payload.
+      def run(payload)
+        payload.group_by { |event| [event['url'], event['type']] }.map { |_, events| events.last }
+      end
+    end
+  end
+end

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -111,12 +111,7 @@ describe Routemaster::APIClient do
       end
 
       let(:callback){
-        subject.on_success do
-          callback_spy.success
-        end
-        subject.on_error do
-          callback_spy.error
-        end
+        subject.on_success { callback_spy.success }.zip(subject.on_error { callback_spy.error })
       }
 
       context "when successful" do

--- a/spec/routemaster/drain/cache_busting_spec.rb
+++ b/spec/routemaster/drain/cache_busting_spec.rb
@@ -3,10 +3,10 @@ require 'spec/support/rack_test'
 require 'spec/support/uses_redis'
 require 'spec/support/uses_dotenv'
 require 'spec/support/events'
-require 'routemaster/drain/expiring_cache'
+require 'routemaster/drain/cache_busting'
 require 'json'
 
-describe Routemaster::Drain::ExpiringCache do
+describe Routemaster::Drain::CacheBusting do
   uses_dotenv
   uses_redis
 

--- a/spec/routemaster/drain/expiring_cache_spec.rb
+++ b/spec/routemaster/drain/expiring_cache_spec.rb
@@ -3,11 +3,10 @@ require 'spec/support/rack_test'
 require 'spec/support/uses_redis'
 require 'spec/support/uses_dotenv'
 require 'spec/support/events'
-require 'routemaster/drain/caching'
-
+require 'routemaster/drain/expiring_cache'
 require 'json'
 
-describe Routemaster::Drain::Caching do
+describe Routemaster::Drain::ExpiringCache do
   uses_dotenv
   uses_redis
 
@@ -38,12 +37,7 @@ describe Routemaster::Drain::Caching do
   it 'increments the event index' do
     ei_double = double(increment: 1)
     allow(Routemaster::EventIndex).to receive(:new).and_return(ei_double)
-    expect(ei_double).to receive(:increment).exactly(4).times
-    perform
-  end
-
-  it 'schedules caching jobs' do
-    expect_any_instance_of(Routemaster::Jobs::Client).to receive(:enqueue).exactly(3).times
+    expect(ei_double).to receive(:increment).exactly(3).times
     perform
   end
 end

--- a/spec/routemaster/middleware/cache_spec.rb
+++ b/spec/routemaster/middleware/cache_spec.rb
@@ -19,11 +19,6 @@ RSpec.describe Routemaster::Middleware::Cache do
   describe '#call' do
     let(:payload) { ['https://example.com/1'] }
 
-    it 'increments the event_index' do
-      expect(cache).to receive(:invalidate)
-      perform
-    end
-
     it 'queues a fetch job' do
       expect(client).to receive(:enqueue).with('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1')
       perform


### PR DESCRIPTION
This Pr:

- Adds a ExpiringCache Drain. This is useful for clients that build their own view of the world and so do not need/want events proactively cached
- Adds ExpireCache middleware
- Adds ExpireCache middleware to the regular caching drain *before* the filtering. This ensure that we never store an old response in the following scenario:

1. event 1 arrives
2. dirty map flagged
3. cache invalidated
4. app notified
5. app fetches resource (v1 is cached)
6. event 2 arrives
7. dirty map already flagged
8. cache not invalidated
9. app fetches resource (v1 still cached)