### PR TITLE
Lt 436/siphon middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Unreleased
+
+Features:
+
+- Adds the Siphon middleware
+
+
 ### 2.4.4 (2017-03-27)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -277,9 +277,10 @@ response.user.show(1)
 
 The more elaborate drains are built with two components which can also be used
 independently,
-[`Dirty::Map`](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Dirty/Map)
-and
-[`Dirty::Filter`](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Dirty/Filter).
+[`Dirty::Map`](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Dirty/Map),
+[`Dirty::Filter`](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Dirty/Filter) and
+[`Middleware::Siphon`](http://www.rubydoc.info/github/deliveroo/routemaster-drain/master/Routemaster/Middleware/Siphon).
+
 
 ### Dirty map
 
@@ -314,6 +315,11 @@ It stores transient state in Redis and will emit `:entity_changed` events
 whenever an entity has changed. This event can usefully be fed into a dirty map,
 as in `Receiver::Filter` for instance.
 
+### Siphon
+
+[`Middleware::Siphon`](http://www.rubydoc.info/github/deliveroo/routemaster-drain/master/Routemaster/Middleware/Siphon) extracts
+payloads from the middleware chain, allowing them to be processed separately. This is useful for event topics where the update frequency is not well suited
+to frequent caching. For example, a location update event which you'd expect to receive every few seconds.
 
 ## Contributing
 
@@ -326,4 +332,3 @@ as in `Receiver::Filter` for instance.
 Do not bump version numbers on branches (a maintainer will do this when cutting
 a release); but please do describe your changes in the `CHANGELOG` (at the top,
 without a version number).
-

--- a/lib/routemaster/drain/basic.rb
+++ b/lib/routemaster/drain/basic.rb
@@ -37,4 +37,3 @@ module Routemaster
     end
   end
 end
-

--- a/lib/routemaster/drain/caching.rb
+++ b/lib/routemaster/drain/caching.rb
@@ -1,6 +1,7 @@
 require 'routemaster/middleware/root_post_only'
 require 'routemaster/middleware/authenticate'
 require 'routemaster/middleware/parse'
+require 'routemaster/middleware/siphon'
 require 'routemaster/middleware/filter'
 require 'routemaster/middleware/dirty'
 require 'routemaster/middleware/cache'
@@ -28,6 +29,7 @@ module Routemaster
           use Middleware::RootPostOnly
           use Middleware::Authenticate, options
           use Middleware::Parse
+          use Middleware::Siphon,       options
           use Middleware::Filter,       options
           use Middleware::Dirty,        options
           use Middleware::Cache,        options
@@ -40,4 +42,3 @@ module Routemaster
     end
   end
 end
-

--- a/lib/routemaster/drain/mapping.rb
+++ b/lib/routemaster/drain/mapping.rb
@@ -1,6 +1,7 @@
 require 'routemaster/middleware/root_post_only'
 require 'routemaster/middleware/authenticate'
 require 'routemaster/middleware/parse'
+require 'routemaster/middleware/siphon'
 require 'routemaster/middleware/filter'
 require 'routemaster/middleware/dirty'
 require 'routemaster/drain/terminator'
@@ -29,6 +30,7 @@ module Routemaster
           use Middleware::RootPostOnly
           use Middleware::Authenticate, options
           use Middleware::Parse
+          use Middleware::Siphon,       options
           use Middleware::Filter,       options
           use Middleware::Dirty,        options
           run terminator
@@ -40,4 +42,3 @@ module Routemaster
     end
   end
 end
-

--- a/lib/routemaster/middleware/authenticate.rb
+++ b/lib/routemaster/middleware/authenticate.rb
@@ -17,7 +17,7 @@ module Routemaster
       include Wisper::Publisher
 
       # @param uuid [Enumerable] a set of accepted authentication tokens
-      def initialize(app, uuid: nil)
+      def initialize(app, uuid: nil, **_)
         @app  = app
         @uuid = uuid || Config.drain_tokens
 
@@ -56,4 +56,3 @@ module Routemaster
     end
   end
 end
-

--- a/lib/routemaster/middleware/cache.rb
+++ b/lib/routemaster/middleware/cache.rb
@@ -7,7 +7,7 @@ require 'routemaster/event_index'
 module Routemaster
   module Middleware
     class Cache
-      def initialize(app, cache:nil, client:nil, queue:nil)
+      def initialize(app, cache:nil, client:nil, queue:nil, **_)
         @app    = app
         @cache  = cache || Routemaster::Cache.new
         @client = client || Routemaster::Jobs::Client.new

--- a/lib/routemaster/middleware/dirty.rb
+++ b/lib/routemaster/middleware/dirty.rb
@@ -11,7 +11,7 @@ module Routemaster
     # The dirty map is passed as `:map` to the constructor and must respond to
     # `#mark` (like `Routemaster::Dirty::Map`).
     class Dirty
-      def initialize(app, dirty_map:nil)
+      def initialize(app, dirty_map: nil, **_)
         @app = app
         @map = dirty_map || Routemaster::Dirty::Map.new
       end
@@ -28,6 +28,3 @@ module Routemaster
     end
   end
 end
-
-
-

--- a/lib/routemaster/middleware/filter.rb
+++ b/lib/routemaster/middleware/filter.rb
@@ -9,7 +9,7 @@ module Routemaster
     class Filter
       # @param filter [Routemaster::Dirty::Filter] an event filter (optional;
       # will be created using the `redis` and `expiry` options if not provided)
-      def initialize(app, filter:nil)
+      def initialize(app, filter:nil, **_)
         @app    = app
         @filter = filter || Routemaster::Dirty::Filter.new
       end
@@ -19,7 +19,7 @@ module Routemaster
         if payload && payload.any?
           env['routemaster.payload'] = @filter.run(payload)
         end
-        @app.call(env) 
+        @app.call(env)
       end
     end
   end

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -1,0 +1,28 @@
+module Routemaster
+  module Middleware
+    class Siphon
+      # Filters out events based on their topic and passes them to a handling class
+      # Usage:
+      #    use Middleware::Siphon, 'some_topic' => SomeTopicSeriesBuilder
+      def initialize(app, processors)
+        @app = app
+        @processors = processors
+      end
+
+      def topics_to_avoid
+        @processors.keys
+      end
+
+      def call(env)
+        time_series, payloads = env.fetch('routemaster.payload', []).partition do |event|
+          topics_to_avoid.include? event['topic']
+        end
+        time_series.each do |event|
+          @processors[event['topic']].new(event).call
+        end
+        env['routemaster.payload'] = payloads
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -1,12 +1,14 @@
 module Routemaster
   module Middleware
+    # Filters out events based on their topic and passes them to a handling class
+    #
+    # `use Middleware::Siphon, 'some_topic' => SomeTopicHandler`
+    #
+    #  Topic handlers are initialized with the full event payload and must respond to `#call`
     class Siphon
-      # Filters out events based on their topic and passes them to a handling class
-      # Usage:
-      #    use Middleware::Siphon, 'some_topic' => SomeTopicHandler
-      def initialize(app, processors)
+      def initialize(app, siphon_events: nil)
         @app = app
-        @processors = processors
+        @processors = siphon_events || {}
       end
 
       def call(env)
@@ -23,7 +25,7 @@ module Routemaster
       private
 
       def topics_to_siphon
-        @topics_to_siphon ||= @processors.keys
+        @topics_to_siphon ||= @processors.keys.map(&:to_s)
       end
     end
   end

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -3,25 +3,27 @@ module Routemaster
     class Siphon
       # Filters out events based on their topic and passes them to a handling class
       # Usage:
-      #    use Middleware::Siphon, 'some_topic' => SomeTopicSeriesBuilder
+      #    use Middleware::Siphon, 'some_topic' => SomeTopicHandler
       def initialize(app, processors)
         @app = app
         @processors = processors
       end
 
-      def topics_to_avoid
-        @processors.keys
-      end
-
       def call(env)
-        time_series, payloads = env.fetch('routemaster.payload', []).partition do |event|
-          topics_to_avoid.include? event['topic']
+        siphoned, non_siphoned = env.fetch('routemaster.payload', []).partition do |event|
+          topics_to_siphon.include? event['topic']
         end
-        time_series.each do |event|
+        siphoned.each do |event|
           @processors[event['topic']].new(event).call
         end
-        env['routemaster.payload'] = payloads
+        env['routemaster.payload'] = non_siphoned
         @app.call(env)
+      end
+
+      private
+
+      def topics_to_siphon
+        @topics_to_siphon ||= @processors.keys
       end
     end
   end

--- a/spec/routemaster/drain/caching_spec.rb
+++ b/spec/routemaster/drain/caching_spec.rb
@@ -3,6 +3,8 @@ require 'spec/support/rack_test'
 require 'spec/support/uses_redis'
 require 'spec/support/uses_dotenv'
 require 'spec/support/events'
+require 'spec/support/siphon'
+
 require 'routemaster/drain/caching'
 require 'json'
 
@@ -10,17 +12,20 @@ describe Routemaster::Drain::Caching do
   uses_dotenv
   uses_redis
 
-  let(:app) { described_class.new }
+  let(:app) { described_class.new options}
   let(:listener) { double 'listener' }
+  let(:options) { {} }
 
   before { app.subscribe(listener, prefix: true) }
 
   let(:path)    { '/' }
-  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) }.to_json }
+  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) } }
   let(:environment) {{ 'CONTENT_TYPE' => 'application/json' }}
-  let(:perform) { post path, payload, environment }
+  let(:perform) { post path, payload.to_json, environment }
 
   before { authorize 'd3m0', 'x' }
+
+  include_examples 'supports siphon'
 
   it 'succeeds' do
     perform

--- a/spec/routemaster/drain/mapping_spec.rb
+++ b/spec/routemaster/drain/mapping_spec.rb
@@ -3,6 +3,7 @@ require 'spec/support/rack_test'
 require 'spec/support/uses_redis'
 require 'spec/support/uses_dotenv'
 require 'spec/support/events'
+require 'spec/support/siphon'
 require 'routemaster/drain/mapping'
 require 'json'
 
@@ -10,17 +11,20 @@ describe Routemaster::Drain::Mapping do
   uses_dotenv
   uses_redis
 
-  let(:app) { described_class.new }
+  let(:app) { described_class.new(options) }
+  let(:options) { {} }
   let(:listener) { double 'listener' }
-  
+
   before { app.subscribe(listener, prefix: true) }
 
   let(:path)    { '/' }
-  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) }.to_json }
+  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) } }
   let(:environment) {{ 'CONTENT_TYPE' => 'application/json' }}
-  let(:perform) { post path, payload, environment }
+  let(:perform) { post path, payload.to_json, environment }
 
   before { authorize 'd3m0', 'x' }
+
+  include_examples 'supports siphon'
 
   it 'succeeds' do
     perform
@@ -35,11 +39,11 @@ describe Routemaster::Drain::Mapping do
   end
 
   let(:map) { Routemaster::Dirty::Map.new }
-  
+
   it 'uses dirty map' do
     payload1 = [1,2,3,1].map { |idx| make_event(idx) }.to_json
     payload2 = [1,4,5,2].map { |idx| make_event(idx) }.to_json
-    
+
     post path, payload1, environment
     expect(map.count).to eq(3)
     map.sweep_one("https://example.com/stuff/1") { true }
@@ -48,4 +52,3 @@ describe Routemaster::Drain::Mapping do
     expect(map.count).to eq(4) # 2, 3, 4, 5 (1 is a repeat event, filtered out)
   end
 end
-

--- a/spec/routemaster/middleware/root_post_only_spec.rb
+++ b/spec/routemaster/middleware/root_post_only_spec.rb
@@ -40,7 +40,3 @@ describe Routemaster::Middleware::RootPostOnly do
     end
   end
 end
-
-
-
-

--- a/spec/routemaster/middleware/siphon_spec.rb
+++ b/spec/routemaster/middleware/siphon_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'spec/support/rack_test'
+require 'spec/support/events'
+require 'routemaster/middleware/siphon'
+require 'json'
+
+describe Routemaster::Middleware::Siphon do
+  let(:terminator) { ErrorRackApp.new }
+  let(:app) { described_class.new(terminator, options) }
+
+  let(:perform) do
+    post '/whatever', '', 'routemaster.payload' => payload
+  end
+
+  describe '#call' do
+
+    let(:options) { { filter:filter } }
+    let(:payload) { [ make_event(1), make_event(1).merge({'topic' => 'notstuff'})] }
+
+    context "if no siphon is defined" do
+      let(:options){ {} }
+      it "passes all to the terminator"  do
+        perform
+        expect(terminator.last_env['routemaster.payload']).to eq payload
+      end
+    end
+
+    context "if a 'stuff' syphon is defined" do
+      let(:syphon_double){
+        double(new: syphon_instance)
+      }
+      let(:syphon_instance){
+        double(call: nil)
+      }
+      let(:options){ { 'stuff' => syphon_double } }
+
+      it "calls the syphon with the event" do
+        perform
+        expect(syphon_double).to have_received(:new).with(payload[0])
+        expect(syphon_instance).to have_received(:call)
+      end
+
+      it "passes 'notstuff' to the terminator"  do
+        perform
+        expect(terminator.last_env['routemaster.payload']).to eq [payload[1]]
+      end
+    end
+  end
+end

--- a/spec/routemaster/middleware/siphon_spec.rb
+++ b/spec/routemaster/middleware/siphon_spec.rb
@@ -29,7 +29,7 @@ describe Routemaster::Middleware::Siphon do
     context "if a 'stuff' siphon is defined" do
       let(:siphon_double) { double(new: siphon_instance) }
       let(:siphon_instance) { double(call: nil) }
-      let(:options){ { 'stuff' => siphon_double } }
+      let(:options) { { siphon_events: { 'stuff' => siphon_double } } } 
 
       it "calls the siphon with the event" do
         perform

--- a/spec/routemaster/middleware/siphon_spec.rb
+++ b/spec/routemaster/middleware/siphon_spec.rb
@@ -18,26 +18,23 @@ describe Routemaster::Middleware::Siphon do
     let(:payload) { [ make_event(1), make_event(1).merge({'topic' => 'notstuff'})] }
 
     context "if no siphon is defined" do
-      let(:options){ {} }
+      let(:options) { {} }
+
       it "passes all to the terminator"  do
         perform
         expect(terminator.last_env['routemaster.payload']).to eq payload
       end
     end
 
-    context "if a 'stuff' syphon is defined" do
-      let(:syphon_double){
-        double(new: syphon_instance)
-      }
-      let(:syphon_instance){
-        double(call: nil)
-      }
-      let(:options){ { 'stuff' => syphon_double } }
+    context "if a 'stuff' siphon is defined" do
+      let(:siphon_double) { double(new: siphon_instance) }
+      let(:siphon_instance) { double(call: nil) }
+      let(:options){ { 'stuff' => siphon_double } }
 
-      it "calls the syphon with the event" do
+      it "calls the siphon with the event" do
         perform
-        expect(syphon_double).to have_received(:new).with(payload[0])
-        expect(syphon_instance).to have_received(:call)
+        expect(siphon_double).to have_received(:new).with(payload[0])
+        expect(siphon_instance).to have_received(:call)
       end
 
       it "passes 'notstuff' to the terminator"  do

--- a/spec/support/siphon.rb
+++ b/spec/support/siphon.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples 'supports siphon' do
+  context "if a siphon is defined" do
+    let(:siphon_double) { double(new: siphon_instance) }
+    let(:siphon_instance) { double(call: nil) }
+    let(:options){ { siphon_events: { payload[0]['topic'] => siphon_double } } }
+
+    it "calls the siphon with the event" do
+      perform
+      expect(siphon_double).to have_received(:new).with(payload[0]).at_least(:once)
+      expect(siphon_instance).to have_received(:call).at_least(:once)
+    end
+  end
+end


### PR DESCRIPTION
This Pr:

- Adds Siphon to Caching and Mapping Drains
- Changes the init methods of Cache, Dirty and Filter to allow non named options to be ignored
- Mentions the Siphon in the Readme