### PR TITLE
LT-XXX/Add syphon to cache bust

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -716,7 +716,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+Features:
+
+- Adds the `Siphon` middleware  to `CacheBusting` drain (#45)
+
 ### 2.5.0 (2017-04-11)
 
 Features:

--- a/lib/routemaster/drain/cache_busting.rb
+++ b/lib/routemaster/drain/cache_busting.rb
@@ -1,6 +1,7 @@
 require 'routemaster/middleware/root_post_only'
 require 'routemaster/middleware/authenticate'
 require 'routemaster/middleware/parse'
+require 'routemaster/middleware/siphon'
 require 'routemaster/middleware/expire_cache'
 require 'routemaster/middleware/payload_filter'
 require 'routemaster/middleware/filter'
@@ -25,6 +26,7 @@ module Routemaster
           use Middleware::RootPostOnly
           use Middleware::Authenticate, options
           use Middleware::Parse
+          use Middleware::Siphon,       options
           use Middleware::Filter, { filter: Routemaster::Middleware::PayloadFilter.new }.merge(options)
           use Middleware::ExpireCache
           run terminator

--- a/spec/routemaster/drain/cache_busting_spec.rb
+++ b/spec/routemaster/drain/cache_busting_spec.rb
@@ -3,6 +3,8 @@ require 'spec/support/rack_test'
 require 'spec/support/uses_redis'
 require 'spec/support/uses_dotenv'
 require 'spec/support/events'
+require 'spec/support/siphon'
+
 require 'routemaster/drain/cache_busting'
 require 'json'
 
@@ -10,17 +12,20 @@ describe Routemaster::Drain::CacheBusting do
   uses_dotenv
   uses_redis
 
-  let(:app) { described_class.new }
+  let(:app) { described_class.new options }
   let(:listener) { double 'listener' }
+  let(:options) { {} }
 
   before { app.subscribe(listener, prefix: true) }
 
   let(:path)    { '/' }
-  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) }.to_json }
+  let(:payload) { [1,2,3,1].map { |idx| make_event(idx) } }
   let(:environment) {{ 'CONTENT_TYPE' => 'application/json' }}
-  let(:perform) { post path, payload, environment }
+  let(:perform) { post path, payload.to_json, environment }
 
   before { authorize 'd3m0', 'x' }
+
+  include_examples 'supports siphon'
 
   it 'succeeds' do
     perform


### PR DESCRIPTION
Noticed Syphon was not included in cache bust. Now it is.

Also Rubocop was crashing for me with an out of date spec name.

Might want to consider removing rubocop.yml an using the default with exception style of setting it up.