### PR TITLE
Sweep from dirty map if resource is missing

### DIFF
--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -11,7 +11,7 @@ module Routemaster
           begin
             Routemaster::Cache.new.get(url)
           rescue Errors::ResourceNotFound
-            nil # nothing to cache
+            true # nothing to cache, remove the element from dirty
           end
         end
       end

--- a/lib/routemaster/middleware/dirty.rb
+++ b/lib/routemaster/middleware/dirty.rb
@@ -18,6 +18,7 @@ module Routemaster
 
       def call(env)
         env['routemaster.dirty'] = dirty = []
+
         env.fetch('routemaster.payload', []).each do |event|
           next if event['type'] == 'noop'
           next unless @map.mark(event['url'])

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -1,16 +1,29 @@
 require 'routemaster/jobs/cache_and_sweep'
+require 'routemaster/dirty/map'
 require 'spec_helper'
 
 RSpec.describe Routemaster::Jobs::CacheAndSweep do
+  let(:url) { 'https://example.com/foo' }
+
   subject { described_class.new }
 
   context 'when there is an ResourceNotFound error' do
     before do
-      expect_any_instance_of(Routemaster::Cache).to receive(:get).and_raise(Routemaster::Errors::ResourceNotFound.new(""))
+      allow_any_instance_of(Routemaster::Cache)
+        .to receive(:get)
+        .and_raise(Routemaster::Errors::ResourceNotFound.new(""))
     end
 
     it 'does not bubble up the error' do
-      expect { subject.perform('url') }.to_not raise_error
+      expect { subject.perform(url) }.to_not raise_error
+    end
+
+    it 'sweeps the resource from the dirty map' do
+      expect_any_instance_of(Routemaster::Dirty::Map)
+        .to receive(:sweep_one)
+        .with(url) { |&block| expect(block.call).to eq true }
+
+      subject.perform(url)
     end
   end
 


### PR DESCRIPTION
## Why

`#sweep_one` does not remove the dirty element from the set if the block doesn't evaluate to `true`. If a `ResourceNotFound` error is raised, then we never remove the element from the set, and the cache becomes stale (i.e. it doesn't get busted and it doesn't respond to any other update anymore).

## What

Return `true` inside the block if the resource is not there.