### PR TITLE
(#48) Bust the cache if a resource is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.5.1 (2017-05-10)
+### UNRELEASED
 
 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 ### Unreleased
 
+Bug fixes
+
+- Bust the cache when the resource is not found (#48)
+
+### 2.5.1 (2017-05-10)
+
 Features:
 
 - Adds the `Siphon` middleware  to `CacheBusting` drain (#45)
+
+Bug fixes
+
+- Sweep the dirty map if a resource is missing (#47)
 
 ### 2.5.0 (2017-04-11)
 

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -3,17 +3,24 @@ require 'routemaster/dirty/map'
 
 module Routemaster
   module Jobs
-    # Caches a URL using {Cache}, and sweeps the dirty map
-    # if sucessful.
+    # Caches a URL using {Cache} and sweeps the dirty map if successful.
+    # Busts the cache if the resource was deleted.
     class CacheAndSweep
       def perform(url)
         Dirty::Map.new.sweep_one(url) do
           begin
-            Routemaster::Cache.new.get(url)
+            cache.get(url)
           rescue Errors::ResourceNotFound
-            true # nothing to cache, remove the element from dirty
+            cache.bust(url)
+            true
           end
         end
+      end
+
+      private
+
+      def cache
+        @cache ||= Routemaster::Cache.new
       end
     end
   end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
 
       subject.perform(url)
     end
+
+    it 'busts the cached version of the resource' do
+      expect_any_instance_of(Routemaster::Cache)
+        .to receive(:bust)
+        .with(url)
+
+      subject.perform(url)
+    end
   end
 
   context 'when there is any other error' do


### PR DESCRIPTION
## Why

The missing resource is correctly removed from the dirty map on 404s (see #47), but the cached version of such resource is not busted, meaning that services will still assume the resource exists even after it was removed.

## What

Bust the cached version of the resource if the service responds with a 404