### PR TITLE
SETI-294 - allow to inject clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+Features
+
+- Allow to supply pre-initialized (distributed) Redis client objects to connect to the Drain Redis and the Cache Redis.
+
 ### 2.5.2 (2017-05-11)
 
 Bug fixes

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add this line to your application's Gemfile:
 
     gem 'routemaster-drain'
 
-**Configuration**
+### Configuration
 
 This gem is configured through the environment, making 12factor compliance
 easier.
@@ -65,6 +65,17 @@ Optional:
   population jobs should be enqueued.
 - `ROUTEMASTER_CACHE_TIMEOUT`: if using the cache, how long before Faraday will timeout fetching the resource. Defaults to 1 second.
 - `ROUTEMASTER_CACHE_VERIFY_SSL`: if using the cache, whether to verify SSL when fetching the resource. Defaults to false.
+
+Alternatively, it's possible to configure the gem to use pre-initialized Redis clients for the Cache Redis, the Drain Redis, or both.
+
+The clients are expected to be instances of `Redis::Distributed`. When configured, the pre-built clients take precendence and the gem won't try to estabilish its own private connection to the Redis instances supplied in the ENV variables. This is helpful if you want to re-use connections in order to reduce the number of connected clients to your Redis servers.
+
+```ruby
+Routemaster::RedisBroker.instance.inject(
+  drain_redis: a_redis_object,
+  cache_redis: another_redis_object
+)
+```
 
 ## Illustrated use cases
 

--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -25,11 +25,11 @@ module Routemaster
     end
 
     def drain_redis
-      RedisBroker.instance.get(:drain_redis, urls: ENV.fetch('ROUTEMASTER_DRAIN_REDIS').split(','))
+      RedisBroker.instance.get(:drain_redis, urls: ENV.fetch('ROUTEMASTER_DRAIN_REDIS', '').split(','))
     end
 
     def cache_redis
-      RedisBroker.instance.get(:cache_redis, urls: ENV.fetch('ROUTEMASTER_CACHE_REDIS').split(','))
+      RedisBroker.instance.get(:cache_redis, urls: ENV.fetch('ROUTEMASTER_CACHE_REDIS', '').split(','))
     end
 
     #

--- a/lib/routemaster/redis_broker.rb
+++ b/lib/routemaster/redis_broker.rb
@@ -29,7 +29,7 @@ module Routemaster
 
     # Allow to inject pre-built Redis clients
     #
-    # Before storing a new connection, ensure that any previously
+    # Before storing a new connection, ensures that any previously
     # set client is properly closed.
     #
     def inject(clients={})

--- a/lib/routemaster/redis_broker.rb
+++ b/lib/routemaster/redis_broker.rb
@@ -7,6 +7,8 @@ module Routemaster
   class RedisBroker
     include Singleton
 
+    DEFAULT_NAMESPACE = 'rm'.freeze
+
     def initialize
       @_connections = {}
       _cleanup
@@ -16,7 +18,7 @@ module Routemaster
       _check_for_fork
       @_connections[name] ||= begin
                                 parsed_url = URI.parse(urls.first)
-                                namespace = parsed_url.path.split('/')[2] || 'rm'
+                                namespace = parsed_url.path.split('/')[2] || DEFAULT_NAMESPACE
                                 Redis::Namespace.new(namespace, redis: Redis::Distributed.new(urls))
                               end
     end
@@ -25,10 +27,24 @@ module Routemaster
       _cleanup
     end
 
+    # Allow to inject pre-built Redis clients
+    #
+    def inject(clients={})
+      @_injected_clients = true
+      clients.each_pair do |name, client|
+        @_connections[name] = Redis::Namespace.new(DEFAULT_NAMESPACE, redis: client)
+      end
+    end
+
     private
 
+    # Do not clean up if the clients are injected by the host application.
+    # In that case connections should be managed the server or worker processes.
+    #
     def _check_for_fork
-      _cleanup unless Process.pid == @_pid
+      return if @_injected_clients
+      return if Process.pid == @_pid
+      _cleanup
     end
 
     def _cleanup

--- a/spec/routemaster/redis_broker_spec.rb
+++ b/spec/routemaster/redis_broker_spec.rb
@@ -4,10 +4,9 @@ require_relative '../../lib/routemaster/redis_broker'
 
 describe Routemaster::RedisBroker do
   subject { Class.new(Routemaster::RedisBroker).instance }
+  let(:urls)   { ['redis://localhost/12'] }
 
   describe "#get" do
-    let(:urls)   { ['redis://localhost/12'] }
-
     context "setting up a redis namespace" do
       let(:redis)           { instance_double(Redis, id: 1) }
       let(:redis_namespace) { instance_double(Redis::Namespace) }
@@ -51,6 +50,31 @@ describe Routemaster::RedisBroker do
         allow(Process).to receive(:pid) { -1 }
         expect(subject.get(:name, urls: urls)).to_not eql(connection)
       end
+    end
+  end
+
+  describe "#inject_clients" do
+    let(:drain_client) { instance_double(Redis) }
+    let(:cache_client) { instance_double(Redis) }
+
+    before do
+      # Reset the singleton
+      Routemaster::RedisBroker.instance_exec { @singleton__instance__ = nil }
+
+      subject.inject(drain_client: drain_client, cache_client: cache_client)
+    end
+
+    it "sets stores the provided clients for later use" do
+      drain = subject.get(:drain_client, urls: urls)
+      expect(drain).to be_a(Redis::Namespace)
+      expect(drain.namespace).to eql 'rm'
+      expect(drain.redis).to eql drain_client
+      
+
+      cache = subject.get(:cache_client, urls: urls)
+      expect(cache).to be_a(Redis::Namespace)
+      expect(cache.namespace).to eql 'rm'
+      expect(cache.redis).to eql cache_client
     end
   end
 end


### PR DESCRIPTION
https://deliveroo.atlassian.net/browse/SETI-294

So that Orderweb can inject its own Redis cache connection, add the ability to inject in the Drain a pre-built Redis client.