### PR TITLE
Remove response class state from the api client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### UNRELEASED
+
+Bug fixes
+
+- Remove state from api client for thread safety (#54)
+
 ### 2.5.4 (2017-06-12)
 
 Bug fixes

--- a/lib/routemaster/resources/rest_resource.rb
+++ b/lib/routemaster/resources/rest_resource.rb
@@ -13,27 +13,24 @@ module Routemaster
       end
 
       def create(params)
-        @client.with_response(Responses::HateoasResponse) do
-          @client.post(expanded_url, body: params)
-        end
+        @client.post(expanded_url, body: params)
       end
 
       def show(id=nil, enable_caching: true)
-        @client.with_response(Responses::HateoasResponse) do
-          @client.get(expanded_url(id: id), options: { enable_caching: enable_caching })
-        end
+        @client.get(expanded_url(id: id), options: { enable_caching: enable_caching })
       end
 
       def index(params: {}, filters: {}, enable_caching: false)
-        @client.with_response(Responses::HateoasEnumerableResponse) do
-          @client.get(expanded_url, params: params.merge(filters), options: { enable_caching: enable_caching })
-        end
+        @client.get(
+          expanded_url, params: params.merge(filters), options: {
+            enable_caching: enable_caching,
+            response_class: Responses::HateoasEnumerableResponse
+          }
+        )
       end
 
       def update(id=nil, params)
-        @client.with_response(Responses::HateoasResponse) do
-          @client.patch(expanded_url(id: id), body: params)
-        end
+        @client.patch(expanded_url(id: id), body: params)
       end
 
       def destroy(id=nil)

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -210,32 +210,4 @@ describe Routemaster::APIClient do
       expect(@req).to have_been_requested
     end
   end
-
-  describe '#with_response' do
-    before { stub_request(:any, //).to_return(status: 200) }
-
-    class DummyResponseA
-      def initialize(res, client: nil); end
-      def dummy_a; true; end
-    end
-
-    class DummyResponseB
-      def initialize(res, client: nil); end
-      def dummy_b; true; end
-    end
-
-    subject { described_class.new(response_class: DummyResponseA) }
-    let(:response) { subject.get('https://example.com') }
-
-    it 'changes the response wrapper during the block' do
-      subject.with_response(DummyResponseB) do
-        expect(response).to respond_to(:dummy_b)
-      end
-    end
-
-    it 'restores the original response wrapper after the block' do
-      subject.with_response(DummyResponseB) {}
-      expect(response).to respond_to(:dummy_a)
-    end
-  end
 end

--- a/spec/routemaster/resources/rest_resource_spec.rb
+++ b/spec/routemaster/resources/rest_resource_spec.rb
@@ -7,8 +7,6 @@ module Routemaster
       let(:client) { double('Client') }
       let(:params) { {} }
 
-      before { allow(client).to receive(:with_response).and_yield }
-
       describe "singular resource" do
         let(:url) { '/resources/1' }
 
@@ -50,7 +48,11 @@ module Routemaster
 
         describe '#index' do
           it 'gets to the given url' do
-            expect(client).to receive(:get).with(url, params: {}, options: { enable_caching: false })
+            expect(client).to receive(:get).with(
+              url, params: {}, options: {
+                enable_caching: false, response_class: Routemaster::Responses::HateoasEnumerableResponse
+              }
+            )
             subject.index
           end
         end


### PR DESCRIPTION
This change removes the state stored inside the api client instance as
this is causing issues when run in a threaded environment.