### PR TITLE
ISEC-61: Change default retention to 90 days

### DIFF
--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -47,7 +47,10 @@ module Routemaster
     end
 
     def cache_expiry
-      Integer(ENV.fetch('ROUTEMASTER_CACHE_EXPIRY', 86_400 * 365))
+      # Do not increase this default value. It's likely that cached data will include PII
+      # and 90 days is the maximum permitted retention period at Deliveroo. A higher value
+      # means we would need to worry about purging caches at the end of the period.
+      Integer(ENV.fetch('ROUTEMASTER_CACHE_EXPIRY', 86_400 * 90))
     end
 
     def cache_auth

--- a/spec/routemaster/config_spec.rb
+++ b/spec/routemaster/config_spec.rb
@@ -1,0 +1,22 @@
+require 'routemaster/config'
+
+RSpec.describe Routemaster::Config do
+  describe '.cache_expiry' do
+    subject { described_class.cache_expiry }
+
+    context 'when using the default' do
+      it 'should be 90 days' do
+        should eq 86_400 * 90
+      end
+    end
+
+    context 'when overridden with ROUTEMASTER_CACHE_EXPIRY' do
+      before { ENV['ROUTEMASTER_CACHE_EXPIRY'] = '123456' }
+      after  { ENV['ROUTEMASTER_CACHE_EXPIRY'] = nil }
+
+      it 'should be the configured value' do
+        should eq 123456
+      end
+    end
+  end
+end


### PR DESCRIPTION
The comment on the default cache time probably explains it all:

```
      # Do not increase this default value. It's likely that cached data will include PII
      # and 90 days is the maximum permitted retention period at Deliveroo. A higher value
      # means we would need to worry about purging caches at the end of the period.
```