### PR TITLE
Set middleware before adapter so Faraday is happy

### DIFF
--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -128,8 +128,8 @@ module Routemaster
         f.response :json, content_type: /\bjson/
         f.use Routemaster::Middleware::ResponseCaching, listener: @listener
         f.use Routemaster::Middleware::Metrics, client: @metrics_client, source_peer: @source_peer
-        f.adapter :typhoeus
         f.use Routemaster::Middleware::ErrorHandling
+        f.adapter :typhoeus
 
         @middlewares.each do |middleware|
           f.use(*middleware)

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.0.0'
+    VERSION = '3.0.1'
   end
 end

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.0.1'
+    VERSION = '3.0.0'
   end
 end


### PR DESCRIPTION
Otherwise logs are littered with 
> WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
