### PR TITLE
SETI-619: Drain/Client keys have no TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### HEAD
+
+Bug fixes:
+
+- Fixes a condition where cache keys in Redis would not expire
+
+
 ### 3.0.1 (2017-08-08)
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Bug fixes:
 
-- Fixes a condition where cache keys in Redis would not expire
+- Fixes a condition where cache keys in Redis would not expire (#63)
 
 
 ### 3.0.1 (2017-08-08)

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Routemaster::RedisBroker.instance.inject(
 ## Upgrading
 
 
-If upgrading from any version between 2.4.0 and 3.0.1, and are using caching, your cache may be
-corrupted by entries that lack a TTL (which will eventually cause your Redis
+If upgrading from any version between 2.4.0 and 3.0.1, and are using caching,
+your cache may be corrupted by entries that lack a TTL (which will eventually
+cause your Redis
 storage to blow up).
 
 We provide a tool to fix your data. With your environment loaded and configured

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ combining middleware.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
   - [Installation](#installation)
+  - [Upgrading](#upgrading)
   - [Illustrated use cases](#illustrated-use-cases)
     - [Simply receive events from Routemaster](#simply-receive-events-from-routemaster)
     - [Receive change notifications without duplicates](#receive-change-notifications-without-duplicates)
@@ -76,6 +77,23 @@ Routemaster::RedisBroker.instance.inject(
   cache_redis: another_redis_object
 )
 ```
+
+## Upgrading
+
+
+If upgrading from any version between 2.4.0 and 3.0.1, and are using caching, your cache may be
+corrupted by entries that lack a TTL (which will eventually cause your Redis
+storage to blow up).
+
+We provide a tool to fix your data. With your environment loaded and configured
+(e.g. from a Rails console), run:
+
+```ruby
+Routemaster::Tasks::FixCacheTTL.new.call
+```
+
+This will scan your cache and add TTLs where missing.
+
 
 ## Illustrated use cases
 

--- a/lib/routemaster/cache_key.rb
+++ b/lib/routemaster/cache_key.rb
@@ -1,7 +1,9 @@
 module Routemaster
   class CacheKey
+    PREFIX = 'cache:'.freeze
+
     def self.url_key(url)
-      "cache:#{url}"
+      "#{PREFIX}#{url}"
     end
   end
 end

--- a/lib/routemaster/event_index.rb
+++ b/lib/routemaster/event_index.rb
@@ -1,21 +1,34 @@
 require 'routemaster/cache_key'
 module Routemaster
   class EventIndex
-    attr_reader :url, :cache
-
     def initialize(url, cache: Config.cache_redis)
       @url = url
       @cache = cache
     end
 
     def increment
-      i = cache.hincrby(CacheKey.url_key(url), 'current_index', 1).to_i
-      Config.logger.debug("DRAIN: Increment #{@url} to #{i}") if Config.logger.debug?
-      i
+      _node do |cache, key|
+        cache.multi do |m|
+          m.hincrby(key, 'current_index', 1)
+          m.expire(key, Config.cache_expiry)
+        end
+      end
+      self
     end
 
     def current
-      (cache.hget(CacheKey.url_key(url), 'current_index') || 0).to_i
+      (@cache.hget(_key, 'current_index') || 0).to_i
+    end
+
+    private
+
+    def _node
+      namespaced_key = "#{@cache.namespace}:#{_key}"
+      yield @cache.redis.node_for(namespaced_key), namespaced_key
+    end
+
+    def _key
+      @_key ||= CacheKey.url_key(@url)
     end
   end
 end

--- a/lib/routemaster/tasks/fix_cache_ttl.rb
+++ b/lib/routemaster/tasks/fix_cache_ttl.rb
@@ -36,7 +36,7 @@ module Routemaster
         node.pipelined do |p|
           keys.zip(ttls).each do |k,ttl|
             next unless ttl < 0
-            node.expire(k, Config.cache_expiry)
+            p.expire(k, Config.cache_expiry)
           end
         end
       end

--- a/lib/routemaster/tasks/fix_cache_ttl.rb
+++ b/lib/routemaster/tasks/fix_cache_ttl.rb
@@ -1,0 +1,45 @@
+require 'routemaster/cache_key'
+
+module Routemaster
+  module Tasks
+    class FixCacheTTL
+      def initialize(cache: Config.cache_redis, batch_size: 100)
+        @cache = cache
+        @batch_size = batch_size
+      end
+
+      def call
+        pattern = "#{@cache.namespace}:#{CacheKey::PREFIX}*"
+        _each_key_batch(pattern) do |node, keys|
+          _fix_keys(node, keys)
+        end
+      end
+
+      private
+
+      def _each_key_batch(pattern)
+        @cache.redis.nodes.each do |node|
+          cursor = 0
+          loop do
+            cursor, keys = node.scan(cursor, count: @batch_size, match: pattern)
+            yield node, keys
+            break if cursor.to_i == 0
+          end
+        end
+      end
+
+      def _fix_keys(node, keys)
+        ttls = node.pipelined do |p|
+          keys.each { |k| p.ttl(k) }
+        end
+
+        node.pipelined do |p|
+          keys.zip(ttls).each do |k,ttl|
+            next unless ttl < 0
+            node.expire(k, Config.cache_expiry)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/routemaster/event_index_spec.rb
+++ b/spec/routemaster/event_index_spec.rb
@@ -1,0 +1,29 @@
+require 'routemaster/event_index'
+require 'spec/support/uses_redis'
+
+describe Routemaster::EventIndex do
+  uses_redis
+
+  let(:cache) { Routemaster::Config.cache_redis }
+  let(:url) { 'https://example.com/widgets/1234' }
+  subject { described_class.new(url, cache: cache) }
+
+  describe '#increment' do
+    it 'increases #current' do
+      expect {
+        subject.increment
+      }.to change {
+        subject.current
+      }.from(0).to(1)
+    end
+
+    it 'leaves all keys with TTLs' do
+      subject.increment
+      cache.redis.nodes.each do |node|
+        node.keys.each do |key|
+          expect(node.ttl(key)).to be > 0
+        end
+      end
+    end
+  end
+end

--- a/spec/routemaster/tasks/fix_cache_ttl_spec.rb
+++ b/spec/routemaster/tasks/fix_cache_ttl_spec.rb
@@ -1,0 +1,41 @@
+require 'routemaster/tasks/fix_cache_ttl'
+require 'spec/support/uses_redis'
+
+describe Routemaster::Tasks::FixCacheTTL do
+  uses_redis
+
+  let(:cache) { Routemaster::Config.cache_redis }
+  subject { described_class.new(cache: cache, batch_size: 5) }
+
+  before do
+    # add keys without a TTL, that aren't cache keys
+    @ignored_keys = (1..20).map { |n| "fubar:#{n}".tap { |k| cache.set(k, n) } }
+
+    # add cache keys with a pre-existing TTL
+    @good_keys = (1..20).map { |n| "cache:good-#{n}".tap { |k| cache.set(k, n, ex: n + 1_000) } }
+    
+    # add cache keys without a TTL
+    @bad_keys = (1..20).map { |n| "cache:bad-#{n}".tap { |k| cache.set("cache:bad-#{n}", n) } }
+  end
+
+  it 'leaves non-cache keys alone' do
+    subject.call
+    @ignored_keys.each { |k|
+      expect(cache.ttl(k)).to eq -1
+    }
+  end
+
+  it 'adds a TTL to broken cache keys' do
+    subject.call
+    @bad_keys.each { |k|
+      expect(cache.ttl(k)).to be > 100_000
+    }
+  end
+
+  it 'leaves the TTL of good cache keys alone' do
+    subject.call
+    @good_keys.each { |k|
+      expect(0..2_000).to include cache.ttl(k)
+    }
+  end
+end


### PR DESCRIPTION
This fixes the "event index" to not leave cache keys without a TTL. This would occur when busting/invalidating the cache.

===

Jira story [#SETI-619](https://deliveroo.atlassian.net/browse/SETI-619) in project *Software Engineering Tools and Infrastructure*:

> Redis keys used and set up by the drain have no TTL, as such our volatile-lru eviction policy never deletes the less recently used keys. 
> 
> *Which app?*
> 
> rom-api-production
> 
> *Which redis instance?*
> 
> [redacted]
> 
> *example(s) of offending keys?*
> 
> Keys 4,333,128
> Keys with expirations 730,110
> 
> `rm:cache:*`