### PR TITLE
Remove unsafe memoization of auth config

### DIFF
--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -54,7 +54,7 @@ module Routemaster
     end
 
     def cache_auth
-      @cache_auth ||= Hashie::Rash.new.tap do |result|
+      Hashie::Rash.new.tap do |result|
         ENV.fetch('ROUTEMASTER_CACHE_AUTH', '').split(',').each do |entry|
           host, username, password = entry.split(':')
           result[Regexp.new(host)] = [username, password]


### PR DESCRIPTION
There seems to be a threading issue with this memoization that
causes the cache auth to be set to an empty Hashie::Rash. I am
not sure if this can be solved by replacing the store with a
simple hash, or other means, but the quickest way to restore
thread safety is to remove the memoization.