### PR TITLE
FLO-24/Add basic circuit to routemaster gets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### HEAD
+
+Features:
+
+ - Adds a circuit breaker to GET requests (#66)
+
 ### 3.0.3 (2017-09-21)
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -329,6 +329,18 @@ response.user.show(1)
 #=> HateoasResponse
 ```
 
+### Circuit Breaker
+
+The client ships with a circuit breaker for get requests, this can be enabled by setting `ENABLE_API_CLIENT_CIRCUIT`. The Circuit Breaker is powered by [Circuitbox](https://github.com/yammer/circuitbox).
+
+The following parameters can be used:
+
+- `CIRCUIT_BREAKER_SLEEP_WINDOW` - The time in seconds the circuit will remain open once it's triggered
+- `CIRCUIT_BREAKER_TIME_WINDOW` - The time in seconds over which it calculates the error rate
+- `CIRCUIT_BREAKER_VOLUME_THRESHOLD` - The minimum amount of requests that can trigger the circuit to open
+- `CIRCUIT_BREAKER_ERROR_THRESHOLD` - The % of errors required for the circuit to open in the sleep window
+
+Each of these settings can be controlled on a per domain basis. To set `CIRCUIT_BREAKER_SLEEP_WINDOW` for `example.com` set `example.com.CIRCUIT_BREAKER_SLEEP_WINDOW`
 
 
 ## Internals

--- a/README.md
+++ b/README.md
@@ -331,16 +331,16 @@ response.user.show(1)
 
 ### Circuit Breaker
 
-The client ships with a circuit breaker for get requests, this can be enabled by setting `ENABLE_API_CLIENT_CIRCUIT`. The Circuit Breaker is powered by [Circuitbox](https://github.com/yammer/circuitbox).
+The client ships with a circuit breaker for get requests, this can be enabled by setting `ROUTEMASTER_ENABLE_API_CLIENT_CIRCUIT`. The Circuit Breaker is powered by [Circuitbox](https://github.com/yammer/circuitbox).
 
 The following parameters can be used:
 
-- `CIRCUIT_BREAKER_SLEEP_WINDOW` - The time in seconds the circuit will remain open once it's triggered
-- `CIRCUIT_BREAKER_TIME_WINDOW` - The time in seconds over which it calculates the error rate
-- `CIRCUIT_BREAKER_VOLUME_THRESHOLD` - The minimum amount of requests that can trigger the circuit to open
-- `CIRCUIT_BREAKER_ERROR_THRESHOLD` - The % of errors required for the circuit to open in the sleep window
+- `ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW` - The time in seconds the circuit will remain open once it's triggered
+- `ROUTEMASTER_CIRCUIT_BREAKER_TIME_WINDOW` - The time in seconds over which it calculates the error rate
+- `ROUTEMASTER_CIRCUIT_BREAKER_VOLUME_THRESHOLD` - The minimum amount of requests that can trigger the circuit to open
+- `ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD` - The % of errors required for the circuit to open in the sleep window
 
-Each of these settings can be controlled on a per domain basis. To set `CIRCUIT_BREAKER_SLEEP_WINDOW` for `example.com` set `example.com.CIRCUIT_BREAKER_SLEEP_WINDOW`
+Each of these settings can be controlled on a per domain basis. To set `ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW` for `example.com` set `example.com.ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW`
 
 
 ## Internals

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -8,6 +8,7 @@ require 'routemaster/middleware/response_caching'
 require 'routemaster/middleware/error_handling'
 require 'routemaster/middleware/metrics'
 require 'routemaster/responses/response_promise'
+require 'routemaster/api_client_circuit'
 
 # This is not a direct dependency, we need to load it early to prevent a
 # circular dependency in hateoas_response.rb
@@ -58,13 +59,14 @@ module Routemaster
     def get(url, params: {}, headers: {}, options: {})
       enable_caching = options.fetch(:enable_caching, true)
       response_class = options[:response_class]
-
-      _wrapped_response _request(
-        :get,
-        url: url,
-        params: params,
-        headers: headers.merge(response_cache_opt_headers(enable_caching))),
-        response_class: response_class
+      APIClientCircuit.new(url).call do
+        _wrapped_response _request(
+          :get,
+          url: url,
+          params: params,
+          headers: headers.merge(response_cache_opt_headers(enable_caching))),
+          response_class: response_class
+      end
     end
 
     # Same as {{get}}, except with

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -22,16 +22,15 @@ module Routemaster
     private
 
     def enabled?
-      ENV.fetch('ENABLE_API_CLIENT_CIRCUIT', 'NO') =~ /\A(YES|TRUE|ON|1)\Z/i
+      ENV.fetch('ROUTEMASTER_ENABLE_API_CLIENT_CIRCUIT', 'NO') =~ /\A(YES|TRUE|ON|1)\Z/i
     end
 
     def circuit
       Circuitbox.circuit(@circuit_name, {
-        sleep_window: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_SLEEP_WINDOW', 60).to_i,
-        time_window: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
-        volume_threshold: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
-        error_threshold:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
-        timeout_seconds:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIMEOUT_SECONDS', 1).to_i,
+        sleep_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW', 60).to_i,
+        time_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
+        volume_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
+        error_threshold:  configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
         cache: Moneta.new(:Redis, backend: Config.cache_redis),
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -31,7 +31,7 @@ module Routemaster
         time_window: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
         volume_threshold: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
         error_threshold:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
-        timeout_seconds:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIMEOUT_SECONDS', 1,).to_i,
+        timeout_seconds:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIMEOUT_SECONDS', 1).to_i,
         cache: Moneta.new(:Redis, backend: Config.cache_redis),
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -27,14 +27,18 @@ module Routemaster
 
     def circuit
       Circuitbox.circuit(@circuit_name, {
+        sleep_window: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_SLEEP_WINDOW', 60).to_i,
+        time_window: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
+        volume_threshold: configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
+        error_threshold:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
+        timeout_seconds:  configuration_setting(@circuit_name, 'CIRCUIT_BREAKER_TIMEOUT_SECONDS', 1,).to_i,
         cache: Moneta.new(:Redis, backend: Config.cache_redis),
-        sleep_window: 60,
-        volume_threshold: 50,
-        time_window: 120,
-        error_threshold:  50,
-        timeout_seconds:  1,
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })
+    end
+
+    def configuration_setting(circuit_name, setting_name, default)
+      ENV.fetch("#{circuit_name}.#{setting_name}", ENV.fetch(setting_name, default))
     end
   end
 end

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -1,0 +1,40 @@
+require 'circuitbox'
+require 'routemaster/errors'
+module Routemaster
+  class APIClientCircuit
+    def initialize(url)
+      url = URI.parse(url) unless url.is_a? URI
+      @circuit_name = url.host.downcase
+    end
+
+    def call(&block)
+      if enabled?
+        begin
+          return circuit.run!(&block)
+        rescue Circuitbox::ServiceFailureError => e
+          raise e.original
+        end
+      else
+        return block.call
+      end
+    end
+
+    private
+
+    def enabled?
+      ENV.fetch('ENABLE_API_CLIENT_CIRCUIT', 'NO') =~ /\A(YES|TRUE|ON|1)\Z/i
+    end
+
+    def circuit
+      Circuitbox.circuit(@circuit_name, {
+        cache: Moneta.new(:Redis, backend: Config.cache_redis),
+        sleep_window: 60,
+        volume_threshold: 50,
+        time_window: 120,
+        error_threshold:  50,
+        timeout_seconds:  1,
+        exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
+      })
+    end
+  end
+end

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'hashie'
   spec.add_runtime_dependency     'redis-namespace'
   spec.add_runtime_dependency     'concurrent-ruby'
+  spec.add_runtime_dependency     'circuitbox'
 end

--- a/spec/routemaster/api_client_circuit_spec.rb
+++ b/spec/routemaster/api_client_circuit_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'spec/support/uses_dotenv'
+require 'spec/support/uses_redis'
+require 'spec/support/uses_webmock'
+require 'routemaster/api_client'
+require 'routemaster/api_client_circuit'
+
+describe Routemaster::APIClientCircuit do
+  uses_webmock
+  uses_redis
+
+  context "when enabled" do
+    before do
+      sb_req
+      allow_any_instance_of(described_class).to receive(:enabled?){ true }
+    end
+
+    let(:url){ 'http://example.com/foobar' }
+
+    let(:sb_req){
+      stub_request(:get, url).to_return(
+        status:   status,
+        body:     { id: 132, type: 'widget' }.to_json,
+        headers:  {
+          'content-type' => 'application/json;v=1'
+        }
+      )
+    }
+
+    def perform
+       Routemaster::APIClient.new.get(url)
+    end
+
+    context "when not erroring" do
+      let(:status) { 200 }
+
+      it "should pass through a response" do
+        expect(perform.status).to eq 200
+      end
+    end
+
+    context "when erroring" do
+      let(:status){ 500 }
+
+      it "should pass through a single error" do
+        expect{ perform }.to raise_error Routemaster::Errors::FatalResource
+        expect(sb_req).to have_been_requested
+      end
+
+      context "after lots of errors" do
+        before do
+          60.times do
+            perform rescue Routemaster::Errors::FatalResource
+          end
+        end
+        it "should limit the amount of requests" do
+          expect(a_request(:get, url)).to have_been_made.at_least_times(49)
+          expect(a_request(:get, url)).to have_been_made.at_most_times(51)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a circuit breaker to APIclient gets.

Circuit box already has a middleware, but I couldn't see a way to have to work on a domain level.

Defaults plucked from the air, but we can ENVise if this looks to be useful