### PR TITLE
make retry_attempts and retry_methods configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Features:
+
+- Consider PATCH requests to always be indempodent so they can be retried on timeouts
+
 ### 3.0.3 (2017-09-21)
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Features:
 
-- Consider PATCH requests to always be indempodent so they can be retried on timeouts
+- Make retry-attempt-count and retry-methods configurable in APIClient.
 
 ### 3.0.3 (2017-09-21)
 

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -123,7 +123,11 @@ module Routemaster
     def connection
       @connection ||= Faraday.new do |f|
         f.request :json
-        f.request :retry, max: 2, interval: 100e-3, backoff_factor: 2
+        f.request :retry,
+          max: 2,
+          interval: 100e-3,
+          backoff_factor: 2,
+          methods: Faraday::Request::Retry::IDEMPOTENT_METHODS + [:patch]
         f.response :mashify
         f.response :json, content_type: /\bjson/
         f.use Routemaster::Middleware::ResponseCaching, listener: @listener

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -34,21 +34,14 @@ module Routemaster
     # all the time to fetch the root resource before doing anything else.
     @@root_resources = {}
 
-    def initialize(middlewares: [],
-                   listener: nil,
-                   response_class: nil,
-                   metrics_client: nil,
-                   source_peer: nil,
-                   retry_attempts: 2,
-                   retry_methods: Faraday::Request::Retry::IDEMPOTENT_METHODS)
-
-      @listener               = listener
-      @middlewares            = middlewares
-      @default_response_class = response_class
-      @metrics_client         = metrics_client
-      @source_peer            = source_peer
-      @retry_attempts         = retry_attempts
-      @retry_methods          = retry_methods
+    def initialize(options = {})
+      @listener               = options.fetch :listener, nil
+      @middlewares            = options.fetch :middlewares, []
+      @default_response_class = options.fetch :response_class, nil
+      @metrics_client         = options.fetch :metrics_client, nil
+      @source_peer            = options.fetch :source_peer, nil
+      @retry_attempts         = options.fetch :retry_attempts, 2
+      @retry_methods          = options.fetch :retry_methods, Faraday::Request::Retry::IDEMPOTENT_METHODS
 
       connection # warm up connection so Faraday does all it's magical file loading in the main thread
     end


### PR DESCRIPTION
We're using PATCH instead of PUT to update partial resource attributes through `Routemaster::APIClient`.

In all of our use cases, PATCH will be indempodent. But since it doesn't _need_ to be indempodent by definition, [Faraday doesn't mark it for retrying](https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb#L23).

We need to be able to retry PATCH requests by default so we can avoid this in the cients of the gem:

```ruby
Model.transaction do
  # the following can timeout despite the records on the external service being updated:
  make_patch_request_to_external_service()

  # even though the external service work is done, this never gets called:
  important_stuff()
end
```

To accomplish this, the PR makes the number of retry-attempts and the methods that should be retried configurable.