### PR TITLE
Replace multi calls with lua scripts

### DIFF
--- a/lib/routemaster/event_index.rb
+++ b/lib/routemaster/event_index.rb
@@ -1,4 +1,5 @@
 require 'routemaster/cache_key'
+require 'routemaster/lua_script'
 module Routemaster
   class EventIndex
     def initialize(url, cache: Config.cache_redis)
@@ -7,12 +8,8 @@ module Routemaster
     end
 
     def increment
-      _node do |cache, key|
-        cache.multi do |m|
-          m.hincrby(key, 'current_index', 1)
-          m.expire(key, Config.cache_expiry)
-        end
-      end
+      LuaScript.new('increment_and_expire_h', @cache)
+                .run([_key],['current_index', Config.cache_expiry])
       self
     end
 

--- a/lib/routemaster/lua/cache_service_response.lua
+++ b/lib/routemaster/lua/cache_service_response.lua
@@ -1,3 +1,1 @@
-local result = redis.call('HMSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6]);
-redis.call('EXPIRE', KEYS[1], ARGV[7]);
-return result
+redis.pcall('HMSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6]);

--- a/lib/routemaster/lua/cache_service_response.lua
+++ b/lib/routemaster/lua/cache_service_response.lua
@@ -1,0 +1,3 @@
+local result = redis.call('HMSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6]);
+redis.call('EXPIRE', KEYS[1], ARGV[7]);
+return result

--- a/lib/routemaster/lua/cache_service_response.lua
+++ b/lib/routemaster/lua/cache_service_response.lua
@@ -1,1 +1,2 @@
-redis.pcall('HMSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6]);
+redis.call('HMSET', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6]);
+redis.call('EXPIRE', KEYS[1], ARGV[7]);

--- a/lib/routemaster/lua/increment_and_expire_h.lua
+++ b/lib/routemaster/lua/increment_and_expire_h.lua
@@ -1,0 +1,3 @@
+local result = redis.call('HINCRBY', KEYS[1], ARGV[1], 1);
+redis.call('EXPIRE', KEYS[1], ARGV[2]);
+return result

--- a/lib/routemaster/lua_script.rb
+++ b/lib/routemaster/lua_script.rb
@@ -1,0 +1,41 @@
+module Routemaster
+  class LuaScript
+    def initialize(name, redis = nil)
+      @redis  = redis || Config.cache_redis
+      @script = load_script(name).strip
+      @digest = digest(@script)
+    end
+
+    def inspect
+      "Luascript: #{@script}"
+    end
+
+    def load_script(name)
+      File.read(File.join(File.dirname(__FILE__), '/lua/', "#{name}.lua"))
+    end
+
+    def digest(script)
+      Digest::SHA1.hexdigest(script)
+    end
+
+    def run(*args)
+      attempts = 0
+      begin
+        attempts += 1
+        eval_script(*args)
+      rescue Redis::CommandError => e
+        load_into_redis
+        raise e if attempts > 1
+        retry
+      end
+    end
+
+    def eval_script(*args)
+      @redis.evalsha(@digest, *args)
+    end
+
+    def load_into_redis
+      @redis.redis.script(:load, @script)
+    end
+  end
+end

--- a/lib/routemaster/lua_script.rb
+++ b/lib/routemaster/lua_script.rb
@@ -35,7 +35,11 @@ module Routemaster
     end
 
     def load_into_redis
-      @redis.redis.script(:load, @script)
+      if @redis.respond_to? :redis
+        @redis.redis.script(:load, @script)
+      else
+        @redis.script(:load, @script)
+      end
     end
   end
 end

--- a/lib/routemaster/middleware/response_caching.rb
+++ b/lib/routemaster/middleware/response_caching.rb
@@ -35,9 +35,10 @@ module Routemaster
               Config.logger.debug("DRAIN: Saving #{url(env)} with a event index of #{event_index}")
             end
 
-            script = LuaScript.new('cache_service_response', @cache)
+            namespaced_key = "#{@cache.namespace}:#{cache_key(env)}"
+            script = LuaScript.new('cache_service_response', @cache.redis.node_for(namespaced_key))
             script.run(
-              ["#{@cache.namespace}:#{cache_key(env)}"],
+              [namespaced_key],
               [
                 body_cache_field(env), response.body,
                 headers_cache_field(env), Marshal.dump(response.headers),

--- a/spec/routemaster/integration/cache_spec.rb
+++ b/spec/routemaster/integration/cache_spec.rb
@@ -38,7 +38,7 @@ describe Routemaster::Cache do
     context 'when there is no previous cached response' do
       it 'makes a HTTP request' do
         perform.call
-        expect(WebMock).to have_requested(:get, url) 
+        expect(WebMock).to have_requested(:get, url)
       end
 
       it 'returns fresh headers' do

--- a/spec/routemaster/lua_script_spec.rb
+++ b/spec/routemaster/lua_script_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'spec/support/uses_redis'
+require 'routemaster/lua_script'
+require 'json'
+
+describe Routemaster::LuaScript do
+  uses_redis
+  context "when loading the increment and expire script" do
+    before { Routemaster::Config.cache_redis.redis.script(:flush) }
+
+    let(:lua_script) do
+      described_class.new('increment_and_expire_h')
+    end
+
+    context "on first run" do
+      it "performs a eval then a eval_sha" do
+        expect(lua_script).to receive(:load_into_redis).and_call_original
+        lua_script.run(['some_hash'], ['some_redis_key', 60])
+      end
+
+      it "increments a hvalue value" do
+        Routemaster::Config.cache_redis.hincrby('some_hash', 'some_redis_key', 1)
+        lua_script.run(['some_hash'], ['some_redis_key', 60])
+        expect(Routemaster::Config.cache_redis.hget('some_hash','some_redis_key')).to eq "2"
+        expect(Routemaster::Config.cache_redis.ttl('some_hash')).to eq 60
+      end
+
+      context "on the second run" do
+        it "performs only a eval_sha" do
+          lua_script.run(['some_hash'], ['some_redis_key', 60])
+          expect(lua_script).not_to receive(:load_into_redis)
+          lua_script.run(['some_hash'], ['some_redis_key', 60])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces `MULTI` redis command with lua scripts.

This is complicated by the fact that we're using distributed redis instances. Since we're going to be using twemproxy should we remove this and let twemproxy deal with it?