### PR TITLE
LOG-2066: Change routemaster-drain to wrap all requests in circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
 - Adds a circuit breaker to all requests (#72)
+- Adds resource url to the error messages
 
 ### 3.2.0 (2017-11-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.3.0 (2017-11-13)
+
+Features:
+
+- Adds a circuit breaker to all requests (#72)
+
 ### 3.2.0 (2017-11-10)
 
 Features:

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.2.0'.freeze
+    VERSION = '3.3.0'.freeze
   end
 end

--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -35,13 +35,13 @@ module Routemaster
 
     class InvalidResource < BaseError
       def message
-        "Invalid Resource Error"
+        "Invalid Resource Error. url #{env.url}"
       end
     end
 
     class ResourceNotFound < BaseError
       def message
-        "Resource Not Found Error"
+        "Resource Not Found Error. url: #{env.url}"
       end
     end
 

--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -29,7 +29,7 @@ module Routemaster
 
     class UnauthorizedResourceAccess < BaseError
       def message
-        "Unauthorized Resource Access Error"
+        "Unauthorized Resource Access Error. url: #{env.url}"
       end
     end
 
@@ -53,7 +53,7 @@ module Routemaster
 
     class ConflictResource < BaseError
       def message
-        "ConflictResourceError Resource Error"
+        "ConflictResourceError Resource Error. url: #{env.url}"
       end
     end
 
@@ -66,7 +66,7 @@ module Routemaster
 
     class ResourceThrottling < BaseError
       def message
-        "Resource Throttling Error"
+        "Resource Throttling Error. url: #{env.url}"
       end
     end
   end

--- a/lib/routemaster/middleware/error_handling.rb
+++ b/lib/routemaster/middleware/error_handling.rb
@@ -13,7 +13,7 @@ module Routemaster
         (412..412) => Errors::IncompatibleVersion,
         (413..413) => Errors::InvalidResource,
         (429..429) => Errors::ResourceThrottling,
-        (407..500) => Errors::FatalResource
+        (407..599) => Errors::FatalResource
       }.freeze
 
       def on_complete(env)

--- a/spec/routemaster/api_client_circuit_spec.rb
+++ b/spec/routemaster/api_client_circuit_spec.rb
@@ -11,53 +11,88 @@ describe Routemaster::APIClientCircuit do
 
   context "when enabled" do
     before do
-      sb_req
       allow_any_instance_of(described_class).to receive(:enabled?){ true }
     end
 
     let(:url){ 'http://example.com/foobar' }
 
-    let(:sb_req){
-      stub_request(:get, url).to_return(
+    def make_request_stub(method, url)
+      stub_request(method, url).to_return(
         status:   status,
         body:     { id: 132, type: 'widget' }.to_json,
         headers:  {
           'content-type' => 'application/json;v=1'
         }
       )
-    }
-
-    def perform
-       Routemaster::APIClient.new.get(url)
     end
 
-    context "when not erroring" do
-      let(:status) { 200 }
+    shared_examples 'performing request' do
+      context "when not erroring" do
+        let(:status) { 200 }
 
-      it "should pass through a response" do
-        expect(perform.status).to eq 200
-      end
-    end
-
-    context "when erroring" do
-      let(:status){ 500 }
-
-      it "should pass through a single error" do
-        expect{ perform }.to raise_error Routemaster::Errors::FatalResource
-        expect(sb_req).to have_been_requested
+        it "should pass through a response" do
+          expect(request.call.status).to eq 200
+        end
       end
 
-      context "after lots of errors" do
-        before do
-          60.times do
-            perform rescue Routemaster::Errors::FatalResource
+      context "when erroring" do
+        let(:status){ 500 }
+
+        it "should pass through a single error" do
+          expect{ request.call }.to raise_error Routemaster::Errors::FatalResource
+          expect(stubbed_request).to have_been_requested
+        end
+
+        context "after lots of errors" do
+          before do
+            60.times do
+              request.call rescue Routemaster::Errors::FatalResource
+            end
+          end
+          it "should limit the amount of requests" do
+            expect(stubbed_request).to have_been_made.at_least_times(49)
+            expect(stubbed_request).to have_been_made.at_most_times(51)
           end
         end
-        it "should limit the amount of requests" do
-          expect(a_request(:get, url)).to have_been_made.at_least_times(49)
-          expect(a_request(:get, url)).to have_been_made.at_most_times(51)
-        end
       end
+    end
+
+    describe '#get' do
+      let(:request) do
+        -> { Routemaster::APIClient.new.get(url) }
+      end
+      let!(:stubbed_request) { make_request_stub(:get, url) }
+
+      include_examples 'performing request'
+    end
+
+    describe '#post' do
+      let(:request) do
+        -> { Routemaster::APIClient.new.post(url) }
+      end
+      let!(:stubbed_request) { make_request_stub(:post, url) }
+
+      include_examples 'performing request'
+    end
+
+    describe '#patch' do
+      let(:request) do
+        -> { Routemaster::APIClient.new.patch(url) }
+      end
+
+      let!(:stubbed_request) { make_request_stub(:patch, url) }
+
+      include_examples 'performing request'
+    end
+
+    describe '#delete' do
+      let(:request) do
+        -> { Routemaster::APIClient.new.delete(url) }
+      end
+
+      let!(:stubbed_request) { make_request_stub(:delete, url) }
+
+      include_examples 'performing request'
     end
   end
 end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Routemaster::Jobs::CacheAndSweep do
   let(:url) { 'https://example.com/foo' }
+  let(:env) { double(Faraday::Env, url: url) }
 
   subject { described_class.new }
 
@@ -11,7 +12,7 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
     before do
       allow_any_instance_of(Routemaster::Cache)
         .to receive(:get)
-        .and_raise(Routemaster::Errors::ResourceNotFound.new(""))
+        .and_raise(Routemaster::Errors::ResourceNotFound.new(env))
     end
 
     it 'does not bubble up the error' do


### PR DESCRIPTION
Circuitbreak all requests, not just GET.
Include resource URL in the error messages
Cover all 5xx errors in error_handling, raise `Errors::FatalResource`.

===

Jira story [#LOG-2066](https://deliveroo.atlassian.net/browse/LOG-2066) in project *Logistics*:

