### PR TITLE
LOG-2121: Modify RouteMaster::ApiClient to raise errors on 405 and 503

### DIFF
--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -69,5 +69,17 @@ module Routemaster
         "Resource Throttling Error"
       end
     end
+
+    class MethodNotAllowed < BaseError
+      def message
+        "Method Not Allowed"
+      end
+    end
+
+    class ServiceNotAvailable < BaseError
+      def message
+        "Service Not Available"
+      end
+    end
   end
 end

--- a/lib/routemaster/middleware/error_handling.rb
+++ b/lib/routemaster/middleware/error_handling.rb
@@ -9,11 +9,13 @@ module Routemaster
         (401..401) => Errors::UnauthorizedResourceAccess,
         (403..403) => Errors::UnauthorizedResourceAccess,
         (404..404) => Errors::ResourceNotFound,
+        (405..405) => Errors::MethodNotAllowed,
         (409..409) => Errors::ConflictResource,
         (412..412) => Errors::IncompatibleVersion,
         (413..413) => Errors::InvalidResource,
         (429..429) => Errors::ResourceThrottling,
-        (407..500) => Errors::FatalResource
+        (407..500) => Errors::FatalResource,
+        (503..503) => Errors::ServiceNotAvailable
       }.freeze
 
       def on_complete(env)

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -21,7 +21,7 @@ describe Routemaster::APIClient do
   let(:port) { 8080 }
   let(:service) do
     TestServer.new(port) do |server|
-      [400, 401, 403, 404, 409, 412, 413, 429, 500].each do |status_code|
+      [400, 401, 403, 404, 405, 409, 412, 413, 429, 500, 503].each do |status_code|
         server.mount_proc "/#{status_code}" do |req, res|
           res.status = status_code
           res.body = { field: 'test' }.to_json
@@ -139,6 +139,10 @@ describe Routemaster::APIClient do
         expect { perform.(host + '/403') }.to raise_error(Routemaster::Errors::UnauthorizedResourceAccess)
       end
 
+      it 'raises a MethodNotAllowed on 405' do
+        expect { perform.(host + '/405') }.to raise_error(Routemaster::Errors::MethodNotAllowed)
+      end
+
       it 'raises an ConflictResource on 409' do
         expect { perform.(host + '/409') }.to raise_error(Routemaster::Errors::ConflictResource)
       end
@@ -157,6 +161,10 @@ describe Routemaster::APIClient do
 
       it 'raises an FatalResource on 500' do
         expect { perform.(host + '/500') }.to raise_error(Routemaster::Errors::FatalResource)
+      end
+
+      it 'raises a ServiceNotAvailable on 503' do
+        expect { perform.(host + '/503') }.to raise_error(Routemaster::Errors::ServiceNotAvailable)
       end
     end
 

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -7,6 +7,7 @@ module WEBrick
   module HTTPServlet
     class ProcHandler
       alias do_PATCH do_GET
+      alias do_DELETE do_GET
     end
   end
 end
@@ -25,7 +26,7 @@ class TestServer
         DocumentRoot: Dir.pwd,
         Logger: WEBrick::Log.new('/dev/null'),
         AccessLog: [nil, nil]
-      ).tap do |server|  
+      ).tap do |server|
         @setup.call(server)
         server.start
       end


### PR DESCRIPTION
Please read description below

===

Jira story [#LOG-2121](https://deliveroo.atlassian.net/browse/LOG-2121) in project *Logistics*:

> The current code in Orderweb uses this gem to post/put/get to several services. Some code paths rely on exception flow to abort transactions, few others rely on the actual response.success? being false (which does not raise exceptions).
> 
> There is currently a bug in the Orderweb communicating to the dispatcher that when we get a 503 or 405 the local cache is updated, transaction succeeds but the respective resources in the Dispatcher are not updated.
> 
> We should modify a gem to raise errors on these HTTP codes