### PR TITLE
Adjust Error messages to include targeted Resource

### DIFF
--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -29,19 +29,19 @@ module Routemaster
 
     class UnauthorizedResourceAccess < BaseError
       def message
-        "Unauthorized Resource Access Error"
+        "Unauthorized Resource Access: #{env.url}"
       end
     end
 
     class InvalidResource < BaseError
       def message
-        "Invalid Resource Error"
+        "Invalid Resource #{env.url}"
       end
     end
 
     class ResourceNotFound < BaseError
       def message
-        "Resource Not Found Error"
+        "Resource Not Found: #{env.url}"
       end
     end
 
@@ -53,7 +53,7 @@ module Routemaster
 
     class ConflictResource < BaseError
       def message
-        "ConflictResourceError Resource Error"
+        "Conflict Resource: #{env.url}"
       end
     end
 
@@ -72,7 +72,7 @@ module Routemaster
 
     class MethodNotAllowed < BaseError
       def message
-        "Method Not Allowed"
+        "Method Not Allowed: #{env.method} #{env.url}"
       end
     end
 

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -3,7 +3,8 @@ require 'routemaster/dirty/map'
 require 'spec_helper'
 
 RSpec.describe Routemaster::Jobs::CacheAndSweep do
-  let(:url) { 'https://example.com/foo' }
+  let(:url)        { 'https://example.com/foo' }
+  let(:sample_env) { OpenStruct.new(url: url, status: 200) }
 
   subject { described_class.new }
 
@@ -11,7 +12,7 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
     before do
       allow_any_instance_of(Routemaster::Cache)
         .to receive(:get)
-        .and_raise(Routemaster::Errors::ResourceNotFound.new(""))
+        .and_raise(Routemaster::Errors::ResourceNotFound.new(sample_env))
     end
 
     it 'does not bubble up the error' do


### PR DESCRIPTION
# What?

Currently a generic UnauthorizedResourceAccess/ResourceNotFound or similar exception is raised by the drain. This change adds the targeted URL from the `env` hash to the error message

# Why?

As we get more services producing messages, it can be hard to nail down exactly which origin is causing problems. This should hopefully allow us to do that, whilst still letting the errors be sensibly grouped in tools like New Relic/Sentry.