### PR TITLE
Add support for HTTP 410 Gone responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### HEAD
+
+_A description of your awesome changes here!_
+
+Features:
+
+- Raises more semantically correct error on 410
+
 ### 3.4.0 (2017-11-16)
 
 Features:

--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -45,6 +45,12 @@ module Routemaster
       end
     end
 
+    class ResourceGone < BaseError
+      def message
+        "Resource Gone: #{env.url}"
+      end
+    end
+
     class FatalResource < BaseError
       def message
         "Fatal Resource Error. body: #{body}, url: #{env.url}, method: #{env.method}"

--- a/lib/routemaster/middleware/error_handling.rb
+++ b/lib/routemaster/middleware/error_handling.rb
@@ -11,6 +11,7 @@ module Routemaster
         (404..404) => Errors::ResourceNotFound,
         (405..405) => Errors::MethodNotAllowed,
         (409..409) => Errors::ConflictResource,
+        (410..410) => Errors::ResourceGone,
         (412..412) => Errors::IncompatibleVersion,
         (413..413) => Errors::InvalidResource,
         (429..429) => Errors::ResourceThrottling,


### PR DESCRIPTION
At the moment, if your service returns an HTTP 410 Gone status code,
routemaster-drain treats it as a fatal error. This is... somewhat
sub-optimal, as we're returning 410s from lots of services on Heroku as
we migrate to AWS.

This adds a new error type (`ResourceGone`) which is thrown if
routemaster-drain receives a 410.