### PR TITLE
Fix fatal error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 _A description of your awesome changes here!_
 
+### 3.5.1 (2018-05-01)
+
+Bug fixes:
+
+- Fix the issue with parsing body in fatal error message. (#78)
+
 ### 3.5.0 (2018-03-07)
 
 Features:

--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -53,7 +53,7 @@ module Routemaster
 
     class FatalResource < BaseError
       def message
-        "Fatal Resource Error. body: #{body}, url: #{env.url}, method: #{env.method}"
+        "Fatal Resource Error. body: #{env.body}, url: #{env.url}, method: #{env.method}"
       end
     end
 

--- a/spec/routemaster/errors_spec.rb
+++ b/spec/routemaster/errors_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'routemaster/errors'
+
+describe Routemaster::Errors::FatalResource do
+  let(:body) { "{ \"foo\": \"bar\" }" }
+  let(:env) { double(body: body, url: '/foo/bar', method: 'GET') }
+  subject(:error) { described_class.new(env) }
+
+  describe "#message" do
+    subject { error.message }
+    it { is_expected.to eq "Fatal Resource Error. body: { \"foo\": \"bar\" }, url: /foo/bar, method: GET" }
+
+    context 'even if the body is string' do
+      let(:body) { "foobar" }
+      it { is_expected.to eq "Fatal Resource Error. body: foobar, url: /foo/bar, method: GET" }
+    end
+  end
+end


### PR DESCRIPTION
### Why

There are times that calls made from routemaster drain receive a `500` but with a `html/text` body. -- My best guess is that these come directly from Cloud Flare, but nevertheless a possibility.

In these situations the `#message` for `Errors::FatalResource` class seem to be attempting to parse the `body` as JSON, which seems to be completely unnecessary.

This keeps causing quite a lot of [this error on new relic](https://rpm.newrelic.com/accounts/881102/applications/32653294/traced_errors/659e4762-4bec-11e8-9dde-0242ac11000a_0_17486)