### PR TITLE
Added the option of what errors to retry faradays requests on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 _A description of your awesome changes here!_
 
+Features:
+
+- Allowed connections to take the exceptions in which to retry requests on (#79)
+
 ### 3.5.1 (2018-05-01)
 
 Bug fixes:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -43,6 +43,7 @@ module Routemaster
       @source_peer            = options.fetch :source_peer, nil
       @retry_attempts         = options.fetch :retry_attempts, 2
       @retry_methods          = options.fetch :retry_methods, Faraday::Request::Retry::IDEMPOTENT_METHODS
+      @retry_exceptions       = options.fetch :retry_exceptions, Faraday::Request::Retry::Options.new.exceptions
 
       connection # warm up connection so Faraday does all it's magical file loading in the main thread
     end
@@ -130,7 +131,8 @@ module Routemaster
           max: @retry_attempts,
           interval: 100e-3,
           backoff_factor: 2,
-          methods: @retry_methods
+          methods: @retry_methods,
+          exceptions: @retry_exceptions
         f.response :mashify
         f.response :json, content_type: /\bjson/
         f.use Routemaster::Middleware::ResponseCaching, listener: @listener


### PR DESCRIPTION
### Why?
In Rider Onboarding we're in the need of being able to specify certain exceptions for faraday to reattempt requests

### What?
- Added the option to specify an array of exceptions which fallback on the default faraday exceptions as defined here: https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb#L59
- Added this array to the construction of the faraday connection
- Added a spec to test the above