### PR TITLE
Added user agent from source peer

### DIFF
--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -111,10 +111,11 @@ module Routemaster
     def _request(method, url:, body: nil, headers:, params: {})
       uri = _assert_uri(url)
       auth = auth_header(uri.host)
+      headers = [*user_agent_header, *auth, *headers].to_h
       connection.public_send(method) do |req|
         req.url uri.to_s
         req.params.merge! params
-        req.headers = headers.merge(auth)
+        req.headers = headers
         req.body = body
       end
     end
@@ -153,6 +154,11 @@ module Routemaster
     def auth_header(host)
       auth_string = Config.cache_auth.fetch(host, []).join(':')
       { 'Authorization' => "Basic #{Base64.strict_encode64(auth_string)}" }
+    end
+
+    def user_agent_header
+      agent = @source_peer || "Faraday v#{Faraday::VERSION}"
+      { 'User-Agent' => agent }
     end
 
     def response_cache_opt_headers(value)

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -55,6 +55,32 @@ describe Routemaster::APIClient do
         expect(req.headers).to include('X-Custom-Header')
       end
     end
+
+    describe 'source peer' do
+      context 'with a source peer' do
+        let(:options) { { source_peer: 'ServiceA' } }
+        let(:fetcher) { described_class.new(options) }
+
+        it 'should set the user agent header to the source peer' do
+          subject.status
+          assert_requested(:get, /example/) do |req|
+            expect(req.headers).to include('User-Agent' => 'ServiceA')
+          end
+        end
+      end
+
+      context 'without a source peer' do
+        let(:options) { { source_peer: nil } }
+        let(:fetcher) { described_class.new(options) }
+
+        it 'should set the user agent header to the faraday version' do
+          subject.status
+          assert_requested(:get, /example/) do |req|
+            expect(req.headers).to include('User-Agent' => "Faraday v#{Faraday::VERSION}" )
+          end
+        end
+      end
+    end
   end
 
   shared_examples 'a wrappable response' do


### PR DESCRIPTION
This PR uses the pre-existing `source_peer` as the user agent when one is passed in, minimizing the work unnecessary for teams to implement the changes.