### PR TITLE
Allow passing client_options to Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ See
 [rubydoc](http://rubydoc.info/github/deliveroo/routemaster-drain/Routemaster/Cache)
 for more details on `Cache`.
 
+If you need to provide configure the `APIClient` used by `Routemaster::Cache`, you can
+configure it using `client_options`:
+
+```ruby
+$cache = Routemaster::Cache.new(client_options: {source_peer: "<your user agent>"})
+```
+
 ### Expire Cache data for all notified resources
 
 You may wish to maintain a coherent cache, but don't need the cache to be warmed

--- a/lib/routemaster/cache.rb
+++ b/lib/routemaster/cache.rb
@@ -18,9 +18,9 @@ module Routemaster
   class Cache
     include Wisper::Publisher
 
-    def initialize(redis: nil, client: nil)
+    def initialize(redis: nil, client: nil, client_options: {})
       @redis  = redis || Config.cache_redis
-      @client = client || APIClient.new(listener: self)
+      @client = client || APIClient.new(client_options.merge(listener: self))
     end
 
     # Bust the cache for a given URL

--- a/spec/routemaster/cache_spec.rb
+++ b/spec/routemaster/cache_spec.rb
@@ -62,6 +62,19 @@ module Routemaster
           perform.status
         end
       end
+
+      context 'with source_peer client option' do
+        let(:options) { {} }
+        subject { described_class.new(client_options: {source_peer: 'test-peer'}) }
+
+        it 'calls get on the api client with given user agent' do
+          perform.status
+
+          assert_requested(:get, url) do |req|
+            expect(req.headers).to include('User-Agent' => 'test-peer' )
+          end
+        end
+      end
     end
 
     describe '#get' do


### PR DESCRIPTION
Adds a `client_options` argument to `Routemaster::Cache`, which will be passed to the constructed `APIClient`. This allows setting `source_peer` on the Cache.