### PR TITLE
allow initialising all middleware classes in the same format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 _A description of your awesome changes here!_
 
+### 3.6.3 (2018-10-17)
+
+Features
+
+- Allow `Routemaster::Middleware::Siphon` to ignore unexpected named arguments
+  within its initialize method
+
 ### 3.6.2 (2018-10-11)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 _A description of your awesome changes here!_
 
-### 3.6.3 (2018-10-17)
+Bug fix:
 
-Features
-
-- Allow `Routemaster::Middleware::Siphon` to ignore unexpected named arguments
-  within its initialize method
+- Allow all middleware classes to be initialised in the same format
 
 ### 3.6.2 (2018-10-11)
 

--- a/lib/routemaster/middleware/authenticate.rb
+++ b/lib/routemaster/middleware/authenticate.rb
@@ -17,9 +17,9 @@ module Routemaster
       include Wisper::Publisher
 
       # @param uuid [Enumerable] a set of accepted authentication tokens
-      def initialize(app, uuid: nil, **_)
+      def initialize(app, options = {})
         @app  = app
-        @uuid = uuid || Config.drain_tokens
+        @uuid = options.fetch(:uuid) { Config.drain_tokens }
 
         unless @uuid.kind_of?(String) || @uuid.kind_of?(Enumerable)
           raise ArgumentError, ':uuid must be a String or Enumerable'

--- a/lib/routemaster/middleware/authenticate.rb
+++ b/lib/routemaster/middleware/authenticate.rb
@@ -16,7 +16,7 @@ module Routemaster
     class Authenticate
       include Wisper::Publisher
 
-      # @param uuid [Enumerable] a set of accepted authentication tokens
+      # options[:uuid] [Enumerable] a set of accepted authentication tokens
       def initialize(app, options = {})
         @app  = app
         @uuid = options.fetch(:uuid) { Config.drain_tokens }

--- a/lib/routemaster/middleware/cache.rb
+++ b/lib/routemaster/middleware/cache.rb
@@ -7,11 +7,11 @@ require 'routemaster/event_index'
 module Routemaster
   module Middleware
     class Cache
-      def initialize(app, cache:nil, client:nil, queue:nil, **_)
+      def initialize(app, options = {})
         @app    = app
-        @cache  = cache || Routemaster::Cache.new
-        @client = client || Routemaster::Jobs::Client.new
-        @queue  = queue || Config.queue_name
+        @cache  = options.fetch(:cache) { Routemaster::Cache.new }
+        @client = options.fetch(:client) { Routemaster::Jobs::Client.new }
+        @queue  = options.fetch(:queue) { Config.queue_name }
       end
 
       def call(env)

--- a/lib/routemaster/middleware/dirty.rb
+++ b/lib/routemaster/middleware/dirty.rb
@@ -11,9 +11,9 @@ module Routemaster
     # The dirty map is passed as `:map` to the constructor and must respond to
     # `#mark` (like `Routemaster::Dirty::Map`).
     class Dirty
-      def initialize(app, dirty_map: nil, **_)
+      def initialize(app, options = {})
         @app = app
-        @map = dirty_map || Routemaster::Dirty::Map.new
+        @map = options.fetch(:dirty_map) { Routemaster::Dirty::Map.new }
       end
 
       def call(env)

--- a/lib/routemaster/middleware/expire_cache.rb
+++ b/lib/routemaster/middleware/expire_cache.rb
@@ -3,9 +3,9 @@ require 'routemaster/cache'
 module Routemaster
   module Middleware
     class ExpireCache
-      def initialize(app, cache:nil, **_)
+      def initialize(app, options = {})
         @app    = app
-        @cache  = cache || Routemaster::Cache.new
+        @cache  = options.fetch(:cache) { Routemaster::Cache.new }
       end
 
       def call(env)

--- a/lib/routemaster/middleware/filter.rb
+++ b/lib/routemaster/middleware/filter.rb
@@ -9,9 +9,9 @@ module Routemaster
     class Filter
       # @param filter [Routemaster::Dirty::Filter] an event filter (optional;
       # will be created using the `redis` and `expiry` options if not provided)
-      def initialize(app, filter:nil, **_)
+      def initialize(app, options = {})
         @app    = app
-        @filter = filter || Routemaster::Dirty::Filter.new
+        @filter = options.fetch(:filter) { Routemaster::Dirty::Filter.new }
       end
 
       def call(env)

--- a/lib/routemaster/middleware/filter.rb
+++ b/lib/routemaster/middleware/filter.rb
@@ -7,7 +7,7 @@ module Routemaster
     #
     # Will use `Routemaster::Dirty::Filter` by default.
     class Filter
-      # @param filter [Routemaster::Dirty::Filter] an event filter (optional;
+      # options[:filter] [Routemaster::Dirty::Filter] an event filter (optional;
       # will be created using the `redis` and `expiry` options if not provided)
       def initialize(app, options = {})
         @app    = app

--- a/lib/routemaster/middleware/metrics.rb
+++ b/lib/routemaster/middleware/metrics.rb
@@ -3,7 +3,7 @@ module Routemaster
     class Metrics
       INTERACTION_KEY = 'api_client'.freeze
 
-      def initialize(app, client: nil, source_peer: nil)
+      def initialize(app, options = {})
         @app    = app
         @client = options[:client]
         @source_peer = options[:source_peer]

--- a/lib/routemaster/middleware/metrics.rb
+++ b/lib/routemaster/middleware/metrics.rb
@@ -5,8 +5,8 @@ module Routemaster
 
       def initialize(app, client: nil, source_peer: nil)
         @app    = app
-        @client = client
-        @source_peer = source_peer
+        @client = options[:client]
+        @source_peer = options[:source_peer]
       end
 
       def call(request_env)

--- a/lib/routemaster/middleware/parse.rb
+++ b/lib/routemaster/middleware/parse.rb
@@ -10,7 +10,7 @@ module Routemaster
     # Lower middlewares (or the app) can access the parsed payload as a hash
     # in +env['routemaster.payload']+
     class Parse
-      def initialize(app)
+      def initialize(app, _options = {})
         @app  = app
       end
 

--- a/lib/routemaster/middleware/response_caching.rb
+++ b/lib/routemaster/middleware/response_caching.rb
@@ -10,11 +10,11 @@ module Routemaster
       VERSION_REGEX = /application\/json;v=(?<version>\S*)/
       RESPONSE_CACHING_OPT_HEADER = 'X-routemaster_drain.opt_cache'.freeze
 
-      def initialize(app, cache: Config.cache_redis, listener: nil)
+      def initialize(app, options = {})
         @app = app
-        @cache = cache
+        @cache = options.fetch(:cache) { Config.cache_redis }
         @expiry = Config.cache_expiry
-        @listener = listener
+        @listener = options[:listener]
       end
 
       def call(env)

--- a/lib/routemaster/middleware/root_post_only.rb
+++ b/lib/routemaster/middleware/root_post_only.rb
@@ -2,7 +2,7 @@ module Routemaster
   module Middleware
     # Rejects all requests but POST to the root path
     class RootPostOnly
-      def initialize(app)
+      def initialize(app, _options = {})
         @app  = app
       end
 

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -6,7 +6,7 @@ module Routemaster
     #
     #  Topic handlers are initialized with the full event payload and must respond to `#call`
     class Siphon
-      def initialize(app, siphon_events: nil)
+      def initialize(app, siphon_events: nil, **_)
         @app = app
         @processors = siphon_events || {}
       end

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -6,9 +6,9 @@ module Routemaster
     #
     #  Topic handlers are initialized with the full event payload and must respond to `#call`
     class Siphon
-      def initialize(app, siphon_events: nil, **_)
+      def initialize(app, options = {})
         @app = app
-        @processors = siphon_events || {}
+        @processors = options.fetch(:siphone_events) { {} }
       end
 
       def call(env)

--- a/lib/routemaster/middleware/siphon.rb
+++ b/lib/routemaster/middleware/siphon.rb
@@ -8,7 +8,7 @@ module Routemaster
     class Siphon
       def initialize(app, options = {})
         @app = app
-        @processors = options.fetch(:siphone_events) { {} }
+        @processors = options.fetch(:siphon_events) { {} }
       end
 
       def call(env)


### PR DESCRIPTION
Allow `Routemaster::Middleware::Siphon` to ignore unexpected named arguments within its initialize method