### PR TITLE
Add descriptive default user agent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 _A description of your awesome changes here!_
 
+Features:
+
+- Prepend default User-Agent with 'RoutemasterDrain'
+
 ### 3.6.3 (2018-10-17)
 
 Bug fix:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -157,7 +157,7 @@ module Routemaster
     end
 
     def user_agent_header
-      agent = @source_peer || "Faraday v#{Faraday::VERSION}"
+      agent = @source_peer || "RoutemasterDrain - Faraday v#{Faraday::VERSION}"
       { 'User-Agent' => agent }
     end
 

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -76,7 +76,7 @@ describe Routemaster::APIClient do
         it 'should set the user agent header to the faraday version' do
           subject.status
           assert_requested(:get, /example/) do |req|
-            expect(req.headers).to include('User-Agent' => "Faraday v#{Faraday::VERSION}" )
+            expect(req.headers).to include('User-Agent' => "RoutemasterDrain - Faraday v#{Faraday::VERSION}" )
           end
         end
       end


### PR DESCRIPTION
**Add descriptive default user agent.**
We should make it clear where different requests are coming from; this will let
us more easily tell that requests from this gem are originating here.