### PR TITLE
Add source peer to middleware cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ _A description of your awesome changes here!_
 Features:
 
 - Prepend default User-Agent with 'RoutemasterDrain'
+- Allow client_options to be passed into `Routemaster::Jobs::CacheAndSweep` jobs
+  so that `Routemaster::Cache` can be instantiated with the correct parameters.
 
 ### 3.6.3 (2018-10-17)
 

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,7 +6,8 @@ module Routemaster
     # Caches a URL using {Cache} and sweeps the dirty map if successful.
     # Busts the cache if the resource was deleted.
     class CacheAndSweep
-      def perform(url)
+      def perform(url, source_peer = nil)
+        @source_peer = source_peer
         Dirty::Map.new.sweep_one(url) do
           begin
             cache.get(url)
@@ -20,8 +21,19 @@ module Routemaster
       private
 
       def cache
-        @cache ||= Routemaster::Cache.new
+        @cache ||= Routemaster::Cache.new(
+          client_options: client_options
+        )
       end
+
+      def client_options
+        if @source_peer
+          { source_peer: @source_peer }
+        else
+          {}
+        end
+      end
+
     end
   end
 end

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,8 +6,8 @@ module Routemaster
     # Caches a URL using {Cache} and sweeps the dirty map if successful.
     # Busts the cache if the resource was deleted.
     class CacheAndSweep
-      def perform(url, options = {})
-        @source_peer = options[:source_peer]
+      def perform(url, client_options = {})
+        @client_options = client_options
         Dirty::Map.new.sweep_one(url) do
           begin
             cache.get(url)
@@ -22,18 +22,9 @@ module Routemaster
 
       def cache
         @cache ||= Routemaster::Cache.new(
-          client_options: client_options
+          client_options: @client_options
         )
       end
-
-      def client_options
-        if @source_peer
-          { source_peer: @source_peer }
-        else
-          {}
-        end
-      end
-
     end
   end
 end

--- a/lib/routemaster/jobs/cache_and_sweep.rb
+++ b/lib/routemaster/jobs/cache_and_sweep.rb
@@ -6,8 +6,8 @@ module Routemaster
     # Caches a URL using {Cache} and sweeps the dirty map if successful.
     # Busts the cache if the resource was deleted.
     class CacheAndSweep
-      def perform(url, source_peer = nil)
-        @source_peer = source_peer
+      def perform(url, options = {})
+        @source_peer = options[:source_peer]
         Dirty::Map.new.sweep_one(url) do
           begin
             cache.get(url)

--- a/lib/routemaster/middleware/cache.rb
+++ b/lib/routemaster/middleware/cache.rb
@@ -12,11 +12,12 @@ module Routemaster
         @cache  = options.fetch(:cache) { Routemaster::Cache.new }
         @client = options.fetch(:client) { Routemaster::Jobs::Client.new }
         @queue  = options.fetch(:queue) { Config.queue_name }
+        @source_peer = options[:source_peer]
       end
 
       def call(env)
         env.fetch('routemaster.dirty', []).each do |url|
-          @client.enqueue(@queue, Routemaster::Jobs::CacheAndSweep, url)
+          @client.enqueue(@queue, Routemaster::Jobs::CacheAndSweep, url, @source_peer)
         end
         @app.call(env)
       end

--- a/lib/routemaster/middleware/cache.rb
+++ b/lib/routemaster/middleware/cache.rb
@@ -12,12 +12,17 @@ module Routemaster
         @cache  = options.fetch(:cache) { Routemaster::Cache.new }
         @client = options.fetch(:client) { Routemaster::Jobs::Client.new }
         @queue  = options.fetch(:queue) { Config.queue_name }
-        @source_peer = options[:source_peer]
+        @cache_client_options = options[:client_options]
       end
 
       def call(env)
         env.fetch('routemaster.dirty', []).each do |url|
-          @client.enqueue(@queue, Routemaster::Jobs::CacheAndSweep, url, @source_peer)
+          @client.enqueue(
+            @queue,
+            Routemaster::Jobs::CacheAndSweep,
+            url,
+            @cache_client_options
+          )
         end
         @app.call(env)
       end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
         with(client_options: client_options).
         and_return(double(get: true))
 
-      subject.perform(url, source_peer)
+      subject.perform(url, {source_peer: source_peer })
     end
   end
 end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
     end
   end
 
-  context 'when a source_peer is not provided' do
-    it 'requests using the source_peer' do
+  context 'when client_options are not provided' do
+    it 'does requests using default client_options' do
       expect(Routemaster::Cache).to receive(:new)
         .with(client_options: {})
         .and_return(double(get: true))
@@ -55,16 +55,15 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
     end
   end
 
-  context 'when a source_peer is provided' do
-    let(:source_peer) { 'test-source-peer' }
-    let(:client_options) { { source_peer: source_peer } }
+  context 'when client_options are provided' do
+    let(:client_options) { { source_peer: 'test-source-peer' } }
 
-    it 'requests using the source_peer' do
-      expect(Routemaster::Cache).to receive(:new).
-        with(client_options: client_options).
-        and_return(double(get: true))
+    it 'requests using the client_options' do
+      expect(Routemaster::Cache).to receive(:new)
+        .with(client_options: client_options)
+        .and_return(double(get: true))
 
-      subject.perform(url, {source_peer: source_peer })
+      subject.perform(url, client_options)
     end
   end
 end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
       expect { subject.perform('url') }.to raise_error("boom")
     end
   end
+
+  context 'when a source_peer is not provided' do
+    it 'requests using the source_peer' do
+      expect(Routemaster::Cache).to receive(:new).
+        with(client_options: {}).
+        and_return(double(get: true))
+
+      subject.perform(url)
+    end
+  end
+
+  context 'when a source_peer is provided' do
+    let(:source_peer) { 'test-source-peer' }
+    let(:client_options) { { source_peer: source_peer } }
+
+    it 'requests using the source_peer' do
+      expect(Routemaster::Cache).to receive(:new).
+        with(client_options: client_options).
+        and_return(double(get: true))
+
+      subject.perform(url, source_peer)
+    end
+  end
 end

--- a/spec/routemaster/jobs/cache_and_sweep_spec.rb
+++ b/spec/routemaster/jobs/cache_and_sweep_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Routemaster::Jobs::CacheAndSweep do
 
   context 'when a source_peer is not provided' do
     it 'requests using the source_peer' do
-      expect(Routemaster::Cache).to receive(:new).
-        with(client_options: {}).
-        and_return(double(get: true))
+      expect(Routemaster::Cache).to receive(:new)
+        .with(client_options: {})
+        .and_return(double(get: true))
 
       subject.perform(url)
     end

--- a/spec/routemaster/middleware/cache_spec.rb
+++ b/spec/routemaster/middleware/cache_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Routemaster::Middleware::Cache do
     let(:payload) { ['https://example.com/1'] }
 
     it 'queues a fetch job' do
-      expect(client).to receive(:enqueue).with('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1')
+      expect(client).to receive(:enqueue).with('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1', nil)
       perform
     end
   end

--- a/spec/routemaster/middleware/cache_spec.rb
+++ b/spec/routemaster/middleware/cache_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Routemaster::Middleware::Cache do
     let(:payload) { ['https://example.com/1'] }
 
     it 'queues a fetch job' do
-      expect(client).to receive(:enqueue).with('routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1', nil)
+      expect(client).to receive(:enqueue).with(
+        'routemaster', Routemaster::Jobs::CacheAndSweep, 'https://example.com/1', nil
+        )
       perform
     end
   end


### PR DESCRIPTION
**Add source peer to middleware cache**
We want to persist the source_peer along the middleware stack - and instantiate
new caches with the same source_peer.