### PR TITLE
Fix middleware load order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Select build variant (Ruby 2.3.4, rails_3)
           command: |
             rbenv local 2.3.4 ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_3.gemfile
 
       - restore_cache:
@@ -60,7 +60,7 @@ jobs:
           name: Select build variant (Ruby 2.3.4, rails_4)
           command: |
             rbenv local 2.3.4 ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_4.gemfile
 
       - restore_cache:
@@ -105,7 +105,7 @@ jobs:
           name: Select build variant (Ruby 2.4.1, rails_4)
           command: |
             rbenv local 2.4.1 ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_4.gemfile
 
       - restore_cache:
@@ -150,7 +150,7 @@ jobs:
           name: Select build variant (Ruby 2.3.4, rails_5)
           command: |
             rbenv local 2.3.4 ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_5.gemfile
 
       - restore_cache:
@@ -195,7 +195,7 @@ jobs:
           name: Select build variant (Ruby 2.4.1, rails_5)
           command: |
             rbenv local 2.4.1 ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_5.gemfile
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,51 +4,6 @@
 version: 2
 jobs:
 
-  build_2.2.7_rails_3:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.2.7, rails_3)
-          command: |
-            rbenv local 2.2.7 ;
-            gem install bundler ;
-            bundle config --local gemfile $PWD/gemfiles/rails_3.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.2.7-rails_3-{{ .Branch }}
-            - v2-bundle-2.2.7-rails_3
-            - v2-bundle-2.2.7
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_3-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_3
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7
-          paths:
-            - ~/project/vendor/bundle
-
   build_2.3.4_rails_3:
     docker:
       - image: deliveroo/multiruby
@@ -91,51 +46,6 @@ jobs:
             - ~/project/vendor/bundle
       - save_cache:
           key: v2-bundle-2.3.4
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.2.7_rails_4:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.2.7, rails_4)
-          command: |
-            rbenv local 2.2.7 ;
-            gem install bundler ;
-            bundle config --local gemfile $PWD/gemfiles/rails_4.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.2.7-rails_4-{{ .Branch }}
-            - v2-bundle-2.2.7-rails_4
-            - v2-bundle-2.2.7
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_4-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_4
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7
           paths:
             - ~/project/vendor/bundle
 
@@ -226,51 +136,6 @@ jobs:
             - ~/project/vendor/bundle
       - save_cache:
           key: v2-bundle-2.4.1
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.2.7_rails_5:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.2.7, rails_5)
-          command: |
-            rbenv local 2.2.7 ;
-            gem install bundler ;
-            bundle config --local gemfile $PWD/gemfiles/rails_5.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.2.7-rails_5-{{ .Branch }}
-            - v2-bundle-2.2.7-rails_5
-            - v2-bundle-2.2.7
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_5-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7-rails_5
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.2.7
           paths:
             - ~/project/vendor/bundle
 
@@ -370,17 +235,11 @@ workflows:
   test:
     jobs:
     
-      - build_2.2.7_rails_3
-    
       - build_2.3.4_rails_3
-    
-      - build_2.2.7_rails_4
     
       - build_2.3.4_rails_4
     
       - build_2.4.1_rails_4
-    
-      - build_2.2.7_rails_5
     
       - build_2.3.4_rails_5
     

--- a/.circleci/config.yml.erb
+++ b/.circleci/config.yml.erb
@@ -2,14 +2,11 @@
 # erb .circleci/config.yml.erb > .circleci/config.yml
 <%
   builds = [
-		['2.2.7', 'rails_3'],
 		['2.3.4', 'rails_3'],
-		['2.2.7', 'rails_4'],
 		['2.3.4', 'rails_4'],
 		['2.4.1', 'rails_4'],
-		['2.2.7', 'rails_5'],
 		['2.3.4', 'rails_5'],
-		['2.4.1', 'rails_5'],
+		['2.4.1', 'rails_5']
   ]
 %>
 version: 2

--- a/.circleci/config.yml.erb
+++ b/.circleci/config.yml.erb
@@ -23,7 +23,7 @@ jobs:
           name: Select build variant (Ruby <%= ruby %>, <%= variant %>)
           command: |
             rbenv local <%= ruby %> ;
-            gem install bundler ;
+            gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/<%= variant %>.gemfile
 
       - restore_cache:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -140,11 +140,12 @@ module Routemaster
         f.use Routemaster::Middleware::ResponseCaching, listener: @listener
         f.use Routemaster::Middleware::Metrics, client: @metrics_client, source_peer: @source_peer
         f.use Routemaster::Middleware::ErrorHandling
-        f.adapter :typhoeus
 
         @middlewares.each do |middleware|
           f.use(*middleware)
         end
+
+        f.adapter :typhoeus
 
         f.options.timeout      = ENV.fetch('ROUTEMASTER_CACHE_TIMEOUT', 1).to_f
         f.options.open_timeout = ENV.fetch('ROUTEMASTER_CACHE_TIMEOUT', 1).to_f

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -53,7 +53,7 @@ describe Routemaster::APIClient do
       subject.status
       assert_requested(:get, /example/) do |req|
         expect(req.headers.keys).to include('X-Custom-Header')
-        expect(req.headers['User-Agent']).to eql "RoutemasterDrain - Faraday v0.15.3"
+        expect(req.headers['User-Agent']).to eql "RoutemasterDrain - Faraday v#{Faraday::VERSION}"
       end
     end
 


### PR DESCRIPTION
The current version prompts a deprecation warning from Faraday version `0.15.x` when custom middleware is used. It's not supposed to be loaded after the adapter is set. 

This is a small, fully backwards compatible change.