### PR TITLE
Feature: Add feature to map to VPC domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 _A description of your awesome changes here!_
 
+### 3.7.0 (2019-07-04)
+
+Features:
+
+- Allow specifying a map of VPC domains to be used
+
 ### 3.6.5 (2019-02-08)
 
 Bug fix:

--- a/lib/routemaster/api_client.rb
+++ b/lib/routemaster/api_client.rb
@@ -109,9 +109,15 @@ module Routemaster
       URI.parse(url)
     end
 
+    def _assert_vpc_uri(uri)
+      return uri unless (vpc_host = Config.vpc_host_mapping[uri.host])
+      uri.clone.tap { |res| res.host = vpc_host }
+    end
+
     def _request(method, url:, body: nil, headers:, params: {})
       uri = _assert_uri(url)
       auth = auth_header(uri.host)
+      uri = _assert_vpc_uri(uri)
       headers = [*user_agent_header, *auth, *headers].to_h
       connection.public_send(method) do |req|
         req.url uri.to_s

--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -62,6 +62,15 @@ module Routemaster
       end
     end
 
+    def vpc_host_mapping
+      Hashie::Rash.new.tap do |result|
+        ENV.fetch('ROUTEMASTER_VPC_HOSTS', '').split(',').each do |entry|
+          host, vpc_host = entry.split(':')
+          result[Regexp.new(host)] = vpc_host
+        end
+      end
+    end
+
     def queue_adapter
       ENV.fetch('ROUTEMASTER_QUEUE_ADAPTER', 'resque').to_sym
     end

--- a/spec/routemaster/api_client_spec.rb
+++ b/spec/routemaster/api_client_spec.rb
@@ -11,12 +11,13 @@ describe Routemaster::APIClient do
   uses_webmock
 
   let(:url) { 'https://example.com/widgets/132' }
+  let(:expected_host) { /example\.com/ }
   let(:headers) {{}}
   let(:fetcher) { described_class.new }
 
   shared_examples 'a GET requester' do
     before do
-      @req = stub_request(:get, /example\.com/).to_return(
+      @req = stub_request(:get, expected_host).to_return(
         status:   200,
         body:     { id: 132, type: 'widget' }.to_json,
         headers:  {
@@ -87,7 +88,7 @@ describe Routemaster::APIClient do
   shared_examples 'a wrappable response' do
     context 'when response_class is present' do
       before do
-        @req = stub_request(:get, /example\.com/).to_return(
+        @req = stub_request(:get, expected_host).to_return(
           status:   200,
           body:     { id: 132, type: 'widget' }.to_json,
           headers:  {
@@ -106,6 +107,18 @@ describe Routemaster::APIClient do
       it 'wraps the response in the response class' do
         expect(subject.dummy).to be_truthy
       end
+
+      context 'when vpc mapping is configured' do
+        let(:expected_host) { /internal-example\.net/ }
+        let(:vpc_mapping) { 'example.com:internal-example.net' }
+        before do
+          stub_const('ENV', ENV.to_h.merge('ROUTEMASTER_VPC_HOSTS' => vpc_mapping))
+        end
+
+        it 'wraps the response in the response class' do
+          expect(subject.dummy).to be_truthy
+        end
+      end
     end
   end
 
@@ -122,7 +135,7 @@ describe Routemaster::APIClient do
 
     context "when setting callbacks" do
       before do
-        stub_request(:get, /example\.com/).to_return(
+        stub_request(:get, expected_host).to_return(
           status:   status,
           body:     { id: 132, type: 'widget' }.to_json,
           headers:  {
@@ -168,7 +181,7 @@ describe Routemaster::APIClient do
     subject { fetcher.post(url, body: {}, headers: headers) }
 
     before do
-      @post_req = stub_request(:post, /example\.com/).to_return(
+      @post_req = stub_request(:post, expected_host).to_return(
         status:   200,
         body:     { id: 132, type: 'widget' }.to_json,
         headers:  {
@@ -191,7 +204,7 @@ describe Routemaster::APIClient do
 
     context 'when request succeeds' do
       before do
-        @put_req= stub_request(:put, /example\.com/).to_return(
+        @put_req= stub_request(:put, expected_host).to_return(
           status:   200,
           body:     { id: 132, type: 'widget' }.to_json,
           headers:  {
@@ -267,7 +280,7 @@ describe Routemaster::APIClient do
 
     context 'when request succeeds' do
       before do
-        @patch_req = stub_request(:patch, /example\.com/).to_return(
+        @patch_req = stub_request(:patch, expected_host).to_return(
           status:   200,
           body:     { id: 132, type: 'widget' }.to_json,
           headers:  {
@@ -327,7 +340,7 @@ describe Routemaster::APIClient do
     subject { fetcher.delete(url, headers: headers) }
 
     before do
-      @delete_req = stub_request(:delete, /example\.com/).to_return(
+      @delete_req = stub_request(:delete, expected_host).to_return(
         status:   204,
       )
     end
@@ -340,7 +353,7 @@ describe Routemaster::APIClient do
 
   describe '#discover' do
     before do
-      @req = stub_request(:get, /example\.com/).to_return(
+      @req = stub_request(:get, expected_host).to_return(
         status:   200,
         body:     { id: 132, type: 'widget' }.to_json,
         headers:  {


### PR DESCRIPTION
### Why

We currently have many places where services communicate to each other using CF-enabled domains and we know this is not good for various reasons most notably for when we are mitigating DDoS attacks.

One reason that it's been very painful to move completely to VPC domains, is that some services return HATEOAS responses that are followed to traverse other resources and not all services return VPC hosts on their HATEOAS `_links` section.

### What

This PR adds a feature to the `api-client` where you can provide a mapping of `host:vpc_host` in an environment variable. Everytime there is a request to `host` we will replace it with `vpc_host` and still use the auth provided for `host`.

This should make it quite easy to migrate to an all-VPC world on rider services (and probably other areas)