### PR TITLE
Trying to rebuild RM Drain library in attempt to solve Atlas caching issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,160 +4,24 @@
 version: 2
 jobs:
 
-  build_2.3.4_rails_3:
+  build_2.5_rails_5:
     docker:
-      - image: deliveroo/multiruby
+      - image: circleci/ruby:2.5.0
       - image: redis:3-alpine
     steps:
       - checkout
 
       - run:
-          name: Select build variant (Ruby 2.3.4, rails_3)
+          name: Install bundler
           command: |
-            rbenv local 2.3.4 ;
-            gem install bundler -v '~> 1.17' ;
-            bundle config --local gemfile $PWD/gemfiles/rails_3.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.3.4-rails_3-{{ .Branch }}
-            - v2-bundle-2.3.4-rails_3
-            - v2-bundle-2.3.4
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.3.4-rails_3-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.3.4-rails_3
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.3.4
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.3.4_rails_4:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.3.4, rails_4)
-          command: |
-            rbenv local 2.3.4 ;
-            gem install bundler -v '~> 1.17' ;
-            bundle config --local gemfile $PWD/gemfiles/rails_4.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.3.4-rails_4-{{ .Branch }}
-            - v2-bundle-2.3.4-rails_4
-            - v2-bundle-2.3.4
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.3.4-rails_4-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.3.4-rails_4
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.3.4
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.4.1_rails_4:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.4.1, rails_4)
-          command: |
-            rbenv local 2.4.1 ;
-            gem install bundler -v '~> 1.17' ;
-            bundle config --local gemfile $PWD/gemfiles/rails_4.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.4.1-rails_4-{{ .Branch }}
-            - v2-bundle-2.4.1-rails_4
-            - v2-bundle-2.4.1
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.4.1-rails_4-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.4.1-rails_4
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.4.1
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.3.4_rails_5:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.3.4, rails_5)
-          command: |
-            rbenv local 2.3.4 ;
             gem install bundler -v '~> 1.17' ;
             bundle config --local gemfile $PWD/gemfiles/rails_5.gemfile
 
       - restore_cache:
           keys: 
-            - v2-bundle-2.3.4-rails_5-{{ .Branch }}
-            - v2-bundle-2.3.4-rails_5
-            - v2-bundle-2.3.4
+            - v2-bundle-2.5.0-rails_5-{{ .Branch }}
+            - v2-bundle-2.5.0-rails_5
+            - v2-bundle-2.5.0
 
       - run: 
           name: Install dependencies
@@ -172,60 +36,15 @@ jobs:
             bundle exec rspec
 
       - save_cache:
-          key: v2-bundle-2.3.4-rails_5-{{ .Branch }}
+          key: v2-bundle-2.5.0-rails_5-{{ .Branch }}
           paths:
             - ~/project/vendor/bundle
       - save_cache:
-          key: v2-bundle-2.3.4-rails_5
+          key: v2-bundle-2.5.0-rails_5
           paths:
             - ~/project/vendor/bundle
       - save_cache:
-          key: v2-bundle-2.3.4
-          paths:
-            - ~/project/vendor/bundle
-
-  build_2.4.1_rails_5:
-    docker:
-      - image: deliveroo/multiruby
-      - image: redis:3-alpine
-    steps:
-      - checkout
-
-      - run:
-          name: Select build variant (Ruby 2.4.1, rails_5)
-          command: |
-            rbenv local 2.4.1 ;
-            gem install bundler -v '~> 1.17' ;
-            bundle config --local gemfile $PWD/gemfiles/rails_5.gemfile
-
-      - restore_cache:
-          keys: 
-            - v2-bundle-2.4.1-rails_5-{{ .Branch }}
-            - v2-bundle-2.4.1-rails_5
-            - v2-bundle-2.4.1
-
-      - run: 
-          name: Install dependencies
-          command: |
-            bundle install --jobs=3 --retry=3 --path=$PWD/vendor/bundle
-
-      - run:
-          name: Run test suite
-          command: |
-            unset RACK_ENV &&
-            unset RAILS_ENV &&
-            bundle exec rspec
-
-      - save_cache:
-          key: v2-bundle-2.4.1-rails_5-{{ .Branch }}
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.4.1-rails_5
-          paths:
-            - ~/project/vendor/bundle
-      - save_cache:
-          key: v2-bundle-2.4.1
+          key: v2-bundle-2.5.0
           paths:
             - ~/project/vendor/bundle
 
@@ -234,14 +53,5 @@ workflows:
   version: 2
   test:
     jobs:
-    
-      - build_2.3.4_rails_3
-    
-      - build_2.3.4_rails_4
-    
-      - build_2.4.1_rails_4
-    
-      - build_2.3.4_rails_5
-    
-      - build_2.4.1_rails_5
+      - build_2.5_rails_5
     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
 
   build_2.5_rails_5:
     docker:
-      - image: circleci/ruby:2.5.0
+      - image: circleci/ruby:2.4.1
       - image: redis:3-alpine
     steps:
       - checkout

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -25,13 +25,14 @@ module Routemaster
       ENV.fetch('ROUTEMASTER_ENABLE_API_CLIENT_CIRCUIT', 'NO') =~ /\A(YES|TRUE|ON|1)\Z/i
     end
 
+
     def circuit
       Circuitbox.circuit(@circuit_name, {
         sleep_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW', 60).to_i,
         time_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
         volume_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
-        error_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
-        cache: Moneta::Adapters::Redis.new(backend: Config.cache_redis),
+        error_threshold:  configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
+        cache: Moneta.new(:Redis, backend: Config.cache_redis),
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })
     end

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -30,8 +30,8 @@ module Routemaster
         sleep_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_SLEEP_WINDOW', 60).to_i,
         time_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
         volume_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
-        error_threshold:  configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
-        cache: Moneta.new(:Redis, backend: Config.cache_redis),
+        error_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
+        cache: Moneta::Adapters::Redis.new(backend: Config.cache_redis),
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })
     end

--- a/lib/routemaster/api_client_circuit.rb
+++ b/lib/routemaster/api_client_circuit.rb
@@ -32,7 +32,7 @@ module Routemaster
         time_window: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_TIME_WINDOW', 120).to_i,
         volume_threshold: configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_VOLUME_THRESHOLD', 50).to_i,
         error_threshold:  configuration_setting(@circuit_name, 'ROUTEMASTER_CIRCUIT_BREAKER_ERROR_THRESHOLD', 50).to_i,
-        cache: Moneta.new(:Redis, backend: Config.cache_redis),
+        cache: Moneta::Adapters::Redis.new(backend: Config.cache_redis),
         exceptions: [Routemaster::Errors::FatalResource, Faraday::TimeoutError]
       })
     end

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.6.5'.freeze
+    VERSION = '3.6.6'.freeze
   end
 end

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'redis-namespace'
   spec.add_runtime_dependency     'concurrent-ruby'
   spec.add_runtime_dependency     'circuitbox'
+  spec.add_runtime_dependency     'moneta', '1.0.0'
 end

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'redis-namespace'
   spec.add_runtime_dependency     'concurrent-ruby'
   spec.add_runtime_dependency     'circuitbox'
-  spec.add_runtime_dependency     'moneta', '~> 1.0'
+  spec.add_runtime_dependency     'moneta', '1.0.0'
 end

--- a/routemaster-drain.gemspec
+++ b/routemaster-drain.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'redis-namespace'
   spec.add_runtime_dependency     'concurrent-ruby'
   spec.add_runtime_dependency     'circuitbox'
-  spec.add_runtime_dependency     'moneta', '1.0.0'
+  spec.add_runtime_dependency     'moneta', '~> 1.0'
 end


### PR DESCRIPTION
Current version of RM API client never deletes cache keys related to circuitbox.

This PR attempts to rebuild the RM Drain to see if this helps to solve the issue.