### PR TITLE
Raise error on `502 Bad Gateway`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ### HEAD
 
 _A description of your awesome changes here!_
+
+Features:
+
+- Raises error on `502 Bad Gateway`
+
 ### 3.6.7 (2021-02-11)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ _A description of your awesome changes here!_
 
 Features:
 
-- Raises error on `502 Bad Gateway`
+- Raises error on `502 Bad Gateway` [#94](https://github.com/deliveroo/routemaster-drain/pull/94)
 
 ### 3.6.7 (2021-02-11)
 

--- a/lib/routemaster/errors.rb
+++ b/lib/routemaster/errors.rb
@@ -82,6 +82,12 @@ module Routemaster
       end
     end
 
+    class BadGateway < BaseError
+      def message
+        "Bad Gateway"
+      end
+    end
+
     class ServiceNotAvailable < BaseError
       def message
         "Service Not Available"

--- a/lib/routemaster/middleware/error_handling.rb
+++ b/lib/routemaster/middleware/error_handling.rb
@@ -16,6 +16,7 @@ module Routemaster
         (413..413) => Errors::InvalidResource,
         (429..429) => Errors::ResourceThrottling,
         (407..500) => Errors::FatalResource,
+        (502..502) => Errors::BadGateway,
         (503..503) => Errors::ServiceNotAvailable
       }.freeze
 

--- a/spec/routemaster/integration/api_client_spec.rb
+++ b/spec/routemaster/integration/api_client_spec.rb
@@ -21,7 +21,7 @@ describe Routemaster::APIClient do
   let(:port) { 8080 }
   let(:service) do
     TestServer.new(port) do |server|
-      [400, 401, 403, 404, 405, 409, 412, 413, 429, 500, 503].each do |status_code|
+      [400, 401, 403, 404, 405, 409, 412, 413, 429, 500, 502, 503].each do |status_code|
         server.mount_proc "/#{status_code}" do |req, res|
           res.status = status_code
           res.body = { field: 'test' }.to_json
@@ -161,6 +161,10 @@ describe Routemaster::APIClient do
 
       it 'raises an FatalResource on 500' do
         expect { perform.(host + '/500') }.to raise_error(Routemaster::Errors::FatalResource)
+      end
+
+      it 'raises a BadGateway on 502' do
+        expect { perform.(host + '/502') }.to raise_error(Routemaster::Errors::BadGateway)
       end
 
       it 'raises a ServiceNotAvailable on 503' do


### PR DESCRIPTION
What it says on the tin 😄 

The error was not supported and that caused some odd behaviours in apps using the client.
Something I've seen happen is that an app will not catch the error and thus try to parse a JSON body, which then will raise an exception (as usually the body is a simple HTML in case of a bad gateway). This causes an error to bubble up even though the expectation is that all errors would be caught by doing `rescue Routemaster::Errors::BaseError`.

This PR in rider-payments can provide some more context: https://github.com/deliveroo/rider-payments/pull/840/files