### PR TITLE
version: bump to 3.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 _A description of your awesome changes here!_
 
+### 3.6.8
+
 Features:
 
 - Raises error on `502 Bad Gateway` [#94](https://github.com/deliveroo/routemaster-drain/pull/94)

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.6.7'.freeze
+    VERSION = '3.6.8'.freeze
   end
 end


### PR DESCRIPTION
A PR was recently merged adding 502 http errors, so let's bump the version and release it