### PR TITLE
Bump version to 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 _A description of your awesome changes here!_
 
+### 3.7.1
+
 Features:
 
 - Add ruby 3 compability

--- a/lib/routemaster/drain.rb
+++ b/lib/routemaster/drain.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Drain
-    VERSION = '3.7.0'.freeze
+    VERSION = '3.7.1'.freeze
   end
 end


### PR DESCRIPTION
Changes made in the recent PR to fix ruby 3 issues and fix pipelines.

Reference PR - https://github.com/deliveroo/routemaster-drain/pull/104