### PR TITLE
[im-2290] Instrument timeout exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+.idea
 .bundle/
 doc/
 .yardoc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 _A description of your awesome changes here!_
 
+- Instrument timeout exceptions (#110)
+
 ### 3.7.1
 
 Features:

--- a/lib/routemaster/middleware/metrics.rb
+++ b/lib/routemaster/middleware/metrics.rb
@@ -22,6 +22,9 @@ module Routemaster
           rescue Routemaster::Errors::BaseError => e
             increment_response_count(response_tags(e.env))
             raise e
+          rescue Faraday::TimeoutError => e
+            increment_response_count(%W[source:#{source_peer} destination:#{request_env.url.host} status:timeout])
+            raise e
           end
         end
       end


### PR DESCRIPTION
## DESCRIPTION

JIRA Ticket: [im-2290](https://deliveroo.atlassian.net/browse/im-2290)

CHANGELOG:

Instrument timeout exceptions. There are a few tests failing on the PR, but these are unrelated to my changes and have been failing on the CI for some time now.

