### PR TITLE
[OWT-4439] Reduce TTL on Routemaster cache expiry

### DIFF
--- a/lib/routemaster/config.rb
+++ b/lib/routemaster/config.rb
@@ -50,7 +50,7 @@ module Routemaster
       # Do not increase this default value. It's likely that cached data will include PII
       # and 90 days is the maximum permitted retention period at Deliveroo. A higher value
       # means we would need to worry about purging caches at the end of the period.
-      Integer(ENV.fetch('ROUTEMASTER_CACHE_EXPIRY', 86_400 * 90))
+      Integer(ENV.fetch('ROUTEMASTER_CACHE_EXPIRY', 86_400 * 60))
     end
 
     def cache_auth


### PR DESCRIPTION
TTL of Routemaster cache expiry is being reduced as part of fix for incident [#im-4986 ](https://deliveroo.slack.com/archives/C0A72L1KUG3).

 Two OW Redis clusters ow-cache-03-redis7 and ow-cache-04-redis7 are at max memory usage.
 

-  [https://app.datadoghq.com/dashboard/8ub-hfg-qg3/-redis-metrics-production-ow-cache-03[…]=sliding&from_ts=1736240953444&to_ts=1767776953444&live=true](https://app.datadoghq.com/dashboard/8ub-hfg-qg3/-redis-metrics-production-ow-cache-03-redis7-global?fromUser=false&fullscreen_end_ts=1767780010133&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1736244010133&fullscreen_widget=8000882063979983&refresh_mode=sliding&from_ts=1736240953444&to_ts=1767776953444&live=true)
- [https://app.datadoghq.com/dashboard/8ub-hfg-qg3/-redis-metrics-production-ow-cache-04[…]=sliding&from_ts=1736244022931&to_ts=1767780022931&live=true](https://app.datadoghq.com/dashboard/8ub-hfg-qg3/-redis-metrics-production-ow-cache-04-redis7-global?fromUser=false&fullscreen_end_ts=1767780023234&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1736244023234&fullscreen_widget=8000882063979983&refresh_mode=sliding&from_ts=1736244022931&to_ts=1767780022931&live=true)

we are reducing ROUTEMASTER_CACHE_EXPIRY  [env var](https://github.com/deliveroo/routemaster-drain/blob/master/lib/routemaster/config.rb#L53) on orderweb(currently at 90 days). Hopefully this should bring down the redis usage capacity.
 
 
 